### PR TITLE
Allow weights to be = 0

### DIFF
--- a/pmd_beamphysics/interfaces/gpt.py
+++ b/pmd_beamphysics/interfaces/gpt.py
@@ -25,7 +25,7 @@ def write_gpt(particle_group,
 
     assert particle_group.species == 'electron' # TODO: add more species
     
-    assert np.all(particle_group.weight >= 0), 'ParticleGroup.weight must be > 0'
+    assert np.all(particle_group.weight >= 0), 'ParticleGroup.weight must be >= 0'
     
     q = -e_charge
     

--- a/pmd_beamphysics/interfaces/gpt.py
+++ b/pmd_beamphysics/interfaces/gpt.py
@@ -25,7 +25,7 @@ def write_gpt(particle_group,
 
     assert particle_group.species == 'electron' # TODO: add more species
     
-    assert np.all(particle_group.weight > 0), 'ParticleGroup.weight must be > 0'
+    assert np.all(particle_group.weight >= 0), 'ParticleGroup.weight must be > 0'
     
     q = -e_charge
     


### PR DESCRIPTION
Fix asset statement to allow weights to be >= 0 when interfacing to GPT