### PR TITLE
Add track_field_1df

### DIFF
--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -917,14 +917,14 @@ class ParticleGroup:
 # helper functions for ParticleGroup class
     
     
-def single_particle(x=0,
-                   px=0,
-                   y=0,
-                   py=0,
-                   z=0,
-                   pz=0,
-                   t=0,
-                   weight=1,
+def single_particle(x=0.0,
+                   px=0.0,
+                   y=0.0,
+                   py=0.0,
+                   z=0.0,
+                   pz=0.0,
+                   t=0.0,
+                   weight=1.0,
                    status=1,
                    species='electron'):
     """


### PR DESCRIPTION
This adds an additional `track_field_1df` that is similar to `track_field_1d`, except that it uses a function Ez_f that the user provides. The default method is set to `'RK23'`, which seems to perform better in practical examples.