### PR TITLE
Remove np.complex (depreciated) 

### DIFF
--- a/pmd_beamphysics/interfaces/simion.py
+++ b/pmd_beamphysics/interfaces/simion.py
@@ -174,3 +174,17 @@ def simion_ion_file_particles_to_particle_data(filename, flip_x_to_z=True):
     
     return data
 
+def KE_AZ_EL_to_momentum(KE, AZ, EL):
+
+    p = np.sqrt( (KE + mec2)**2 - mec2**2) # total momentum in [eV/c]
+    phi = AZ*(np.pi/180)
+    theta = EL*(np.pi/180)
+
+    px = p*np.cos(theta)*np.cos(phi)
+    py = p*np.sin(theta)
+    pz = p*np.cos(theta)*np.sin(phi)
+
+    return (px, py, pz)
+
+
+

--- a/pmd_beamphysics/writers.py
+++ b/pmd_beamphysics/writers.py
@@ -115,8 +115,8 @@ def write_pmd_field(h5, data, name=None):
         u = pg_units(key)   
         
         # Ensure complex
-        val = val.astype(np.complex)
-        
+        val = val.astype(complex)
+
         # Write
         g2 = write_component_data(g, key, val, unit=u)            
     


### PR DESCRIPTION
Removes np.complex from `writers.py` as this alias is deprecated, replaced with `complex`.