### PR TITLE
Add equal_weights option to resample, fix Genesis4 bug

### DIFF
--- a/pmd_beamphysics/interfaces/genesis.py
+++ b/pmd_beamphysics/interfaces/genesis.py
@@ -398,7 +398,8 @@ def write_genesis4_distribution(particle_group,
     If particles are at different z, they will be drifted to the same z, 
     because the output should have different times. 
     
-    If any of the weights are different, the bunch will be resampled.
+    If any of the weights are different, the bunch will be resampled
+    to have equal weights.
     Note that this can be very slow for a large number of particles.
     
     """
@@ -423,7 +424,7 @@ def write_genesis4_distribution(particle_group,
         n = len(P)
         if verbose:
             print(f'Resampling {n} weighted particles')      
-        P = P.resample(n)        
+        P = P.resample(n, equal_weights=True)        
         
     for k in ['x', 'xp', 'y', 'yp', 't']:
         h5[k] = P[k]

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -1064,8 +1064,8 @@ class ParticleGroup:
         return deepcopy(self)    
     
     @functools.wraps(resample_particles)
-    def resample(self, n=0):
-        data = resample_particles(self, n)
+    def resample(self, n=0, equal_weights=False):
+        data = resample_particles(self, n, equal_weights=equal_weights)
         return ParticleGroup(data=data)
     
     # Internal sorting


### PR DESCRIPTION
Previously `write_genesis4_distribution` was incorrectly resampling with weights for export. Genesis4 requires equal weights for this type of distribution. This PR:
- adds `equal_weights` option to `ParticleGroup.resample`, defaulting to False.
- Corrects `write_genesis4_distribution` to use this. 