### PR TITLE
Fixed writing particle data to gpt format, tested with tracking

### DIFF
--- a/pmd_beamphysics/interfaces/gpt.py
+++ b/pmd_beamphysics/interfaces/gpt.py
@@ -1,4 +1,4 @@
-from pmd_beamphysics.units import e_charge
+from pmd_beamphysics.units import e_charge, c_light
 from pmd_beamphysics.interfaces.superfish import fish_complex_to_real_fields
 
 import numpy as np
@@ -16,19 +16,16 @@ def write_gpt(particle_group,
     asci2gdf -o particles.gdf particles.txt
     
     This routine makes ASCII particles, with column labels:
-        'x', 'y', 'z', 'GBx', 'GBy', 'GBz', 't', 'q', 'nmacro'
+        'x', 'y', 'z', 'GBx', 'GBy', 'GBz', 't', 'q', 'm', 'nmacro'
     in SI units. 
-    
-    For now, only electrons are supported.
 
     """
-
-    assert particle_group.species == 'electron' # TODO: add more species
     
     assert np.all(particle_group.weight >= 0), 'ParticleGroup.weight must be >= 0'
     
-    q = -e_charge
-    
+    q = particle_group.species_charge
+    mc2 = particle_group.mass               # returns pmd_beamphysics.species.mass_of(particle_group.species) [eV]
+    m = mc2 * (e_charge / c_light**2)
     n = particle_group.n_particle
     gamma = particle_group.gamma
     
@@ -41,13 +38,13 @@ def write_gpt(particle_group,
         'GBz': gamma*particle_group.beta_z,
         't': particle_group.t,
         'q': np.full(n, q),
-        'nmacro': particle_group.weight/e_charge}
+        'm': np.full(n, m),
+        'nmacro': np.abs(particle_group.weight/q)}
     
     if hasattr(particle_group, 'id'):
         dat['ID'] = particle_group.id
     else:
         dat['ID'] = np.arange(1, particle_group['n_particle']+1)       
-    
     
     header = ' '.join(list(dat))
 


### PR DESCRIPTION
# Description

This PR opens up the allowed particle species that can be written in GPT format.  This list supported by ParticleGroup is electron, positron, and proton.

# How was this tested?

This was tested with the devel version of Lume-GPT by creating a single electron, positron, and proton - all of which given a total momentum of 1 GeV/c.  The particles were then tracked through a bending magnet with radius 1 meter (at 1 GeV/c momentum):

<img width="1139" alt="Screenshot 2024-03-26 at 2 15 11 PM" src="https://github.com/ChristopherMayes/openPMD-beamphysics/assets/36416205/fa871e19-062f-4b36-8559-1ae777309d3b">

Each particle was then tracked using GPT.  We expect the electron to bend up, and the others to bend down, all with the same radius.  We also expect the proton to travel less distance in the same amount of time:

<img width="755" alt="Screenshot 2024-03-26 at 2 15 31 PM" src="https://github.com/ChristopherMayes/openPMD-beamphysics/assets/36416205/7df65215-93b5-4375-927c-8574345a7ae6">

Loading the particles verifies the correct dynamical variables:

<img width="690" alt="Screenshot 2024-03-26 at 2 16 41 PM" src="https://github.com/ChristopherMayes/openPMD-beamphysics/assets/36416205/778c07cb-c0c9-4f51-a470-0d0d37cd3980">
