### PR TITLE
FIX: address np.string_ and ndarray.ptp deprecations in numpy 2.0

### DIFF
--- a/pmd_beamphysics/interfaces/impact.py
+++ b/pmd_beamphysics/interfaces/impact.py
@@ -166,7 +166,7 @@ def write_impact(particle_group,
         z = -betac*particle_group['t']  
 
         # Get z span
-        z_ptp = z.ptp()
+        z_ptp = np.ptp(z)
         # Add tiny padding
         z_pad = 1e-20 # Tiny pad 
         
@@ -546,7 +546,7 @@ def create_impact_solrf_fieldmap_fourier(field_mesh,
             zmax = z.max()
         else:
             zmin = 0
-            zmax = z.ptp()
+            zmax = np.ptp(z)
             
         fcoefs = dat['fcoefs']
         
@@ -628,7 +628,7 @@ def create_impact_solrf_fieldmap_derivatives(field_mesh,
     rfdata = []
     
     z = field_mesh.coord_vec('z')
-    L = z.ptp()
+    L = np.ptp(z)
     
     info = {'format':'solrf'}
     field = {}    

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -671,7 +671,7 @@ class ParticleGroup:
         Simple average `current = charge / dt` in [A], with `dt =  (max_t - min_t)`
         If particles are in $t$ coordinates, will try` dt = (max_z - min_z)*c_light*beta_z`
         """
-        dt = self.t.ptp()  # ptp 'peak to peak' is max - min
+        dt = np.ptp(self.t)  # ptp 'peak to peak' is max - min
         if dt == 0:
             # must be in t coordinates. Calc with 
             dt = self.z.ptp() / (self.avg('beta_z')*c_light)

--- a/pmd_beamphysics/tools.py
+++ b/pmd_beamphysics/tools.py
@@ -4,7 +4,7 @@ def fstr(s):
     """
     Makes a fixed string for h5 files
     """
-    return np.string_(s)
+    return np.bytes_(s)
 
 
 
@@ -43,7 +43,7 @@ def decode_attr(a):
         return a.decode('utf-8')
     
     if isinstance(a, np.ndarray):
-        if a.dtype.type is np.string_:
+        if a.dtype.type is np.bytes_:
             a = a.astype(str)
         if len(a) == 1:
             return a[0]
@@ -71,7 +71,7 @@ def encode_attr(a):
     
     if isinstance(a, np.ndarray):
         if a.dtype.type is np.str_:
-            a = a.astype(np.string_)
+            a = a.astype(np.bytes_)
             
     return a
 

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -376,7 +376,7 @@ def nice_array(a):
         x = a[0]
     else:
         a = np.array(a)
-        x = max(a.ptp(), abs(np.mean(a))) # Account for tiny spread
+        x = max(np.ptp(a), abs(np.mean(a))) # Account for tiny spread
         
     fac, prefix = nice_scale_prefix( x )
     


### PR DESCRIPTION
## Changes

* `np.string_` recommends changing to `np.bytes_`
* `ndarray.ptp()` -> `np.ptp(ndarray)`

## Context

[numpy 2.0](https://numpy.org/doc/stable/release/2.0.0-notes.html#deprecations)