### PR TITLE
Update species for H2+

### DIFF
--- a/pmd_beamphysics/species.py
+++ b/pmd_beamphysics/species.py
@@ -11,25 +11,33 @@ mpc2 = scipy.constants.value('proton mass energy equivalent in MeV')*1e6
 
 mhmc2 = mpc2 + mec2 * 2 # H- mass energy equivalent in MeV
 
+mH2pc2 = 2*mpc2 + mec2 # Molecular Hydrogen Ion H2+
+
 e_charge = scipy.constants.e
 c_light = scipy.constants.c
 
 CHARGE_OF = {'electron': -e_charge,
             'positron': e_charge,
             'proton': e_charge,
-            'H-': -e_charge}
+            'H-': -e_charge,
+            'H2+': e_charge,
+            }
 
 CHARGE_STATE = {
     'electron': -1,
     'positron': 1,
     'proton': 1,
-    'H-': -1}
+    'H-': -1,
+    'H2+': +1,
+    }
 
 
 MASS_OF = {'electron': mec2,
            'positron': mec2,
            'proton': mpc2,
-           'H-': mhmc2}
+           'H-': mhmc2,
+           'H2+': mH2pc2,
+           }
 
 
 


### PR DESCRIPTION
This PR adds the molecular hydrogen ion to the species list(s) for ParticleGroup.  The ion consists of two protons and one electron:

```
mH2pc2 = 2*mpc2 + mec2 # Molecular Hydrogen Ion H2+

e_charge = scipy.constants.e
c_light = scipy.constants.c

CHARGE_OF = {'electron': -e_charge,
            'positron': e_charge,
            'proton': e_charge,
            'H-': -e_charge,
            'H2+': e_charge,
            }

CHARGE_STATE = {
    'electron': -1,
    'positron': 1,
    'proton': 1,
    'H-': -1,
    'H2+': +1,
    }


MASS_OF = {'electron': mec2,
           'positron': mec2,
           'proton': mpc2,
           'H-': mhmc2,
           'H2+': mH2pc2,
           }
```

This seems to respect the standard:
<img width="1114" alt="Screenshot 2024-06-29 at 9 56 46 PM" src="https://github.com/ChristopherMayes/openPMD-beamphysics/assets/36416205/44f90d76-21b3-49e6-87db-a82126e21deb">

https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_SpeciesType.md

