### PR TITLE
Add "muon" and "antimuon" as Valid Species for `ParticleGroup`

### DIFF
--- a/pmd_beamphysics/species.py
+++ b/pmd_beamphysics/species.py
@@ -8,9 +8,8 @@ import scipy.constants
 
 mec2 = scipy.constants.value('electron mass energy equivalent in MeV')*1e6
 mpc2 = scipy.constants.value('proton mass energy equivalent in MeV')*1e6
-
+mmc2 = scipy.constants.value('muon mass energy equivalent in MeV')*1e6
 mhmc2 = mpc2 + mec2 * 2 # H- mass energy equivalent in MeV
-
 mH2pc2 = 2*mpc2 + mec2 # Molecular Hydrogen Ion H2+
 
 e_charge = scipy.constants.e
@@ -21,6 +20,8 @@ CHARGE_OF = {'electron': -e_charge,
             'proton': e_charge,
             'H-': -e_charge,
             'H2+': e_charge,
+            'muon': -e_charge,
+            'antimuon': e_charge,
             }
 
 CHARGE_STATE = {
@@ -29,6 +30,8 @@ CHARGE_STATE = {
     'proton': 1,
     'H-': -1,
     'H2+': +1,
+    'muon': -1,
+    'antimuon': 1,
     }
 
 
@@ -37,6 +40,8 @@ MASS_OF = {'electron': mec2,
            'proton': mpc2,
            'H-': mhmc2,
            'H2+': mH2pc2,
+           'muon': mmc2,
+           'antimuon': mmc2,
            }
 
 


### PR DESCRIPTION
This PR adds the particles "muon" and "antimuon" as options for the species of a `ParticleGroup` object. Their mass and change were added to the file `pmd_beamphysics\species.py` and the changes were tested by running some of the example notebooks with the species of the particles manually set to "muon" and "antimuon".