### PR TITLE
FIX: syntax warnings with unsupported escape sequences

### DIFF
--- a/pmd_beamphysics/fields/analysis.py
+++ b/pmd_beamphysics/fields/analysis.py
@@ -12,7 +12,7 @@ import numpy as np
 # Analysis
 
 def accelerating_voltage_and_phase(z, Ez, frequency):
-    """
+    r"""
     Computes the accelerating voltage and phase for a v=c positively charged particle in an accelerating cavity field.
     
         Z = \int Ez * e^{-i k z} dz 
@@ -57,7 +57,7 @@ def track_field_1d(z,
                    debug=False,
                    max_step=None,
                   ):
-    """
+    r"""
     Tracks a particle in a 1d complex electric field Ez, oscillating as Ez * exp(-i omega t)
     
     Uses scipy.integrate.solve_ivp to track the particle. 
@@ -181,7 +181,7 @@ def track_field_1df(Ez_f,
                    max_step=None,
                     method='RK23'
                   ):
-    """
+    r"""
     Similar to track_field_1d, execpt uses a function Ez_f
     
     Tracks a particle in a 1d electric field Ez(z, t)

--- a/pmd_beamphysics/labels.py
+++ b/pmd_beamphysics/labels.py
@@ -122,7 +122,7 @@ def texlabel(key: str):
     if key.startswith('bunching'):
         wavelength = parse_bunching_str(key)
         x, _, prefix = nice_array(wavelength)
-        return f'\mathrm{{bunching~at}}~{x:.1f}~\mathrm{{ {prefix}m }}'
+        return fr'\mathrm{{bunching~at}}~{x:.1f}~\mathrm{{ {prefix}m }}'
     
     return None
     

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -678,7 +678,7 @@ class ParticleGroup:
         return self.charge / dt
     
     def bunching(self, wavelength):
-        """
+        r"""
         Calculate the normalized bunching parameter, which is the magnitude of the 
         complex sum of weighted exponentials at a given point.
     


### PR DESCRIPTION
Addresses the following:

```
pmd_beamphysics/fields/analysis.py:18:13: W605 invalid escape sequence '\i'
pmd_beamphysics/fields/analysis.py:67:33: W605 invalid escape sequence '\s'
pmd_beamphysics/fields/analysis.py:71:13: W605 invalid escape sequence '\R'
pmd_beamphysics/fields/analysis.py:71:22: W605 invalid escape sequence '\e'
pmd_beamphysics/fields/analysis.py:71:30: W605 invalid escape sequence '\o'
pmd_beamphysics/fields/analysis.py:193:33: W605 invalid escape sequence '\s'
pmd_beamphysics/fields/analysis.py:197:13: W605 invalid escape sequence '\R'
pmd_beamphysics/fields/analysis.py:197:22: W605 invalid escape sequence '\e'
pmd_beamphysics/fields/analysis.py:197:30: W605 invalid escape sequence '\o'
pmd_beamphysics/labels.py:125:18: W605 invalid escape sequence '\m'
pmd_beamphysics/labels.py:125:49: W605 invalid escape sequence '\m'
pmd_beamphysics/particles.py:688:14: W605 invalid escape sequence '\l'
pmd_beamphysics/particles.py:688:31: W605 invalid escape sequence '\l'
pmd_beamphysics/particles.py:688:37: W605 invalid escape sequence '\s'
pmd_beamphysics/particles.py:688:66: W605 invalid escape sequence '\s'
pmd_beamphysics/particles.py:692:11: W605 invalid escape sequence '\('
pmd_beamphysics/particles.py:692:16: W605 invalid escape sequence '\)'
pmd_beamphysics/particles.py:693:11: W605 invalid escape sequence '\('
pmd_beamphysics/particles.py:693:14: W605 invalid escape sequence '\l'
pmd_beamphysics/particles.py:693:22: W605 invalid escape sequence '\)'
pmd_beamphysics/particles.py:694:11: W605 invalid escape sequence '\('
pmd_beamphysics/particles.py:694:25: W605 invalid escape sequence '\p'
pmd_beamphysics/particles.py:694:30: W605 invalid escape sequence '\l'
pmd_beamphysics/particles.py:694:39: W605 invalid escape sequence '\)'
pmd_beamphysics/particles.py:695:11: W605 invalid escape sequence '\('
pmd_beamphysics/particles.py:695:18: W605 invalid escape sequence '\)'
```