### PR TITLE
Divide by c option 

### DIFF
--- a/docs/examples/labels.ipynb
+++ b/docs/examples/labels.ipynb
@@ -205,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/docs/examples/particle_examples.ipynb
+++ b/docs/examples/particle_examples.ipynb
@@ -13,6 +13,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pmd_beamphysics import ParticleGroup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Nicer plotting\n",
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
@@ -25,15 +44,6 @@
    "metadata": {},
    "source": [
     "# Basic Usage"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pmd_beamphysics import ParticleGroup"
    ]
   },
   {
@@ -79,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = P.plot(\"x\", \"px\", figsize=(8, 8))"
+    "P.plot(\"x\", \"px\", figsize=(8, 8))"
    ]
   },
   {
@@ -491,6 +501,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "All keys allow a special synatax with `/c` to divide by the speed of light. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P[\"sigma_z/c\"], P.units(\"sigma_z/c\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## status, weight, id, copy\n",
     "\n",
     "`status == 1` is alive, otherwise dead. Set the first ten particles to a different status.\n",
@@ -745,7 +771,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "P.plot(\"z\", \"x\")"
+    "P.plot(\"z/c\", \"x\")"
    ]
   },
   {

--- a/docs/examples/particle_examples.ipynb
+++ b/docs/examples/particle_examples.ipynb
@@ -13,16 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from pmd_beamphysics import ParticleGroup"
    ]
   },
@@ -501,7 +491,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All keys allow a special synatax with `/c` to divide by the speed of light. For example:"
+    "There is a special key `z/c` to divide `z` by the speed of light to get units of `s`. This key also works with statistics:"
    ]
   },
   {
@@ -510,7 +500,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "P[\"sigma_z/c\"], P.units(\"sigma_z/c\")"
+    "P[\"sigma_z/c\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P.units(\"sigma_z/c\")"
    ]
   },
   {

--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -296,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/pmd_beamphysics/labels.py
+++ b/pmd_beamphysics/labels.py
@@ -120,15 +120,6 @@ def texlabel(key: str):
         tex1 = texlabel(subkeys[1])
         return rf"\left<{tex0}, {tex1}\right>"
 
-    # '/c' suffix for dividing by the speed of light
-    nc = key.count("/c")
-    if nc > 0:
-        key = key.replace("/c", "")
-        if nc == 1:
-            return texlabel(key) + "/c"
-        else:
-            return texlabel(key) + f"/c^{nc}"
-
     if key.startswith("bunching"):
         wavelength = parse_bunching_str(key)
         x, _, prefix = nice_array(wavelength)

--- a/pmd_beamphysics/labels.py
+++ b/pmd_beamphysics/labels.py
@@ -127,7 +127,7 @@ def texlabel(key: str):
         if nc == 1:
             return texlabel(key) + "/c"
         else:
-            return texlabel(key) + rf"/c^{nc}"
+            return texlabel(key) + f"/c^{nc}"
 
     if key.startswith("bunching"):
         wavelength = parse_bunching_str(key)

--- a/pmd_beamphysics/labels.py
+++ b/pmd_beamphysics/labels.py
@@ -115,7 +115,7 @@ def texlabel(key: str):
                 return rf"\left<{tex0}\right>"
 
     if key.startswith("cov_"):
-        subkeys = key[4:].split("__")
+        subkeys = key.removeprefix("cov_").split("__")
         tex0 = texlabel(subkeys[0])
         tex1 = texlabel(subkeys[1])
         return rf"\left<{tex0}, {tex1}\right>"

--- a/pmd_beamphysics/labels.py
+++ b/pmd_beamphysics/labels.py
@@ -4,10 +4,10 @@ TEXLABEL = {
     # 'status'
     "t": "t",
     "energy": "E",
-    "kinetic_energy": r"E_{kinetic}",
+    "kinetic_energy": r"E_\text{kinetic}",
     # 'mass',
-    # 'higher_order_energy_spread',
-    # 'higher_order_energy',
+    "higher_order_energy_spread": r"\sigma_{E_{(2)}}",
+    "higher_order_energy": r"E_{(2)}",
     "Ex": "E_x",
     "Ey": "E_y",
     "Ez": "E_z",
@@ -35,20 +35,20 @@ TEXLABEL = {
     "gamma": r"\gamma",
     "theta": r"\theta",
     "charge": "Q",
-    "twiss_alpha_x": r"Twiss\ \alpha_x",
-    "twiss_beta_x": r"Twiss\ \beta_x",
-    "twiss_gamma_x": r"Twiss\ \gamma_x",
-    "twiss_eta_x": r"Twiss\ \eta_x",
-    "twiss_etap_x": r"Twiss\ \eta'_x",
-    "twiss_emit_x": r"Twiss\ \epsilon_{x}",
-    "twiss_norm_emit_x": r"Twiss\ \epsilon_{n, x}",
-    "twiss_alpha_y": r"Twiss\ \alpha_y",
-    "twiss_beta_y": r"Twiss\ \beta_y",
-    "twiss_gamma_y": r"Twiss\ \gamma_y",
-    "twiss_eta_y": r"Twiss\ \eta_y",
-    "twiss_etap_y": r"Twiss\ \eta'_y",
-    "twiss_emit_y": r"Twiss\ \epsilon_{y}",
-    "twiss_norm_emit_y": r"Twiss\ \epsilon_{n, y}",
+    "twiss_alpha_x": r"\text{Twiss}\ \alpha_x",
+    "twiss_beta_x": r"\text{Twiss}\ \beta_x",
+    "twiss_gamma_x": r"\text{Twiss}\ \gamma_x",
+    "twiss_eta_x": r"\text{Twiss}\ \eta_x",
+    "twiss_etap_x": r"\text{Twiss}\ \eta'_x",
+    "twiss_emit_x": r"\text{Twiss}\ \epsilon_{x}",
+    "twiss_norm_emit_x": r"\text{Twiss}\ \epsilon_{n, x}",
+    "twiss_alpha_y": r"\text{Twiss}\ \alpha_y",
+    "twiss_beta_y": r"\text{Twiss}\ \beta_y",
+    "twiss_gamma_y": r"\text{Twiss}\ \gamma_y",
+    "twiss_eta_y": r"\text{Twiss}\ \eta_y",
+    "twiss_etap_y": r"\text{Twiss}\ \eta'_y",
+    "twiss_emit_y": r"\text{Twiss}\ \epsilon_{y}",
+    "twiss_norm_emit_y": r"\text{Twiss}\ \epsilon_{n, y}",
     # 'species_charge',
     # 'weight',
     "average_current": r"I_{av}",
@@ -98,6 +98,7 @@ def texlabel(key: str):
     if key in TEXLABEL:
         return TEXLABEL[key]
 
+    # Operators
     for prefix in ["sigma_", "mean_", "min_", "max_", "ptp_", "delta_"]:
         if key.startswith(prefix):
             pre = prefix[:-1]
@@ -114,17 +115,26 @@ def texlabel(key: str):
                 return rf"\left<{tex0}\right>"
 
     if key.startswith("cov_"):
-        subkeys = key.strip("cov_").split("__")
+        subkeys = key[4:].split("__")
         tex0 = texlabel(subkeys[0])
         tex1 = texlabel(subkeys[1])
         return rf"\left<{tex0}, {tex1}\right>"
+
+    # '/c' suffix for dividing by the speed of light
+    nc = key.count("/c")
+    if nc > 0:
+        key = key.replace("/c", "")
+        if nc == 1:
+            return texlabel(key) + "/c"
+        else:
+            return texlabel(key) + rf"/c^{nc}"
 
     if key.startswith("bunching"):
         wavelength = parse_bunching_str(key)
         x, _, prefix = nice_array(wavelength)
         return rf"\mathrm{{bunching~at}}~{x:.1f}~\mathrm{{ {prefix}m }}"
 
-    return None
+    return rf"\mathrm{{ {key} }}"
 
 
 def mathlabel(*keys, units=None, tex=True):
@@ -167,6 +177,7 @@ def mathlabel(*keys, units=None, tex=True):
         label_list = [texlabel(key) or rf"\mathrm{{ {key} }}" for key in keys]
         label = ", ".join(label_list)
         if units:
+            units = units.replace("*", r"{\cdot}")
             label = rf"{label}~(\mathrm{{ {units} }} )"
 
         return rf"${label}$"

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -783,6 +783,12 @@ class ParticleGroup:
         if not isinstance(key, str):
             return particle_parts(self, key)
 
+        # '/c' suffix for dividing by the speed of light
+        nc = key.count("/c")
+        if nc > 0:
+            key = key.replace("/c", "")
+            return self[key] / (c_light**nc)
+
         if key.startswith("cov_"):
             subkeys = key[4:].split("__")
             assert (

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -783,14 +783,12 @@ class ParticleGroup:
         if not isinstance(key, str):
             return particle_parts(self, key)
 
-        # '/c' suffix for dividing by the speed of light
-        nc = key.count("/c")
-        if nc > 0:
-            key = key.replace("/c", "")
-            return self[key] / (c_light**nc)
+        # 'z/c' special case
+        if key == "z/c":
+            return self["z"] / (c_light)
 
         if key.startswith("cov_"):
-            subkeys = key[4:].split("__")
+            subkeys = key.removeprefix("cov").split("__")
             assert (
                 len(subkeys) == 2
             ), f"Too many properties in covariance request: {key}"

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -788,7 +788,7 @@ class ParticleGroup:
             return self["z"] / (c_light)
 
         if key.startswith("cov_"):
-            subkeys = key.removeprefix("cov").split("__")
+            subkeys = key.removeprefix("cov_").split("__")
             assert (
                 len(subkeys) == 2
             ), f"Too many properties in covariance request: {key}"

--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -340,7 +340,7 @@ def marginal_plot(
         _, hist_prefix = nice_scale_prefix(hist_f / f1)
         ax_marg_x.set_ylabel(f"{hist_prefix}A")
     else:
-        ax_marg_x.set_ylabel(mathlabel(f"{hist_prefix}C/{ux}"))  # Always use tex
+        ax_marg_x.set_ylabel(f"{hist_prefix}" + mathlabel(f"C/{ux}"))  # Always use tex
 
     # Side histogram
     # Old method:
@@ -351,7 +351,7 @@ def marginal_plot(
     hist_width = np.diff(bin_edges)
     hist_y, hist_f, hist_prefix = nice_array(hist / hist_width)
     ax_marg_y.barh(hist_x, hist_y, hist_width, color="gray")
-    ax_marg_y.set_xlabel(mathlabel(f"{hist_prefix}C/{uy}"))  # Always use tex
+    ax_marg_y.set_xlabel(f"{hist_prefix}" + mathlabel(f"C/{uy}"))  # Always use tex
 
     # Turn off tick labels on marginals
     plt.setp(ax_marg_x.get_xticklabels(), visible=False)

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -438,7 +438,7 @@ def plottable_array(x, nice=True, lim=None):
 PARTICLEGROUP_UNITS = {}
 for k in ["n_particle", "status", "id", "n_alive", "n_dead"]:
     PARTICLEGROUP_UNITS[k] = unit("1")
-for k in ["t"]:
+for k in ["t", "z/c"]:
     PARTICLEGROUP_UNITS[k] = unit("s")
 for k in [
     "energy",
@@ -498,15 +498,6 @@ def pg_units(key):
         if key.startswith(prefix):
             nkey = key[len(prefix) :]
             return pg_units(nkey)
-
-    # Handle '/c'  for dividing by the speed of light
-    nc = key.count("/c")
-    if nc > 0:
-        key = key.replace("/c", "")
-        u = pg_units(key)
-        for _ in range(nc):
-            u = u / unit("m") * unit("s")
-        return u
 
     if key.startswith("cov_"):
         subkeys = key.strip("cov_").split("__")

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -493,10 +493,20 @@ def pg_units(key):
     if key in PARTICLEGROUP_UNITS:
         return PARTICLEGROUP_UNITS[key]
 
+    # Operators
     for prefix in ["sigma_", "mean_", "min_", "max_", "ptp_", "delta_"]:
         if key.startswith(prefix):
             nkey = key[len(prefix) :]
             return pg_units(nkey)
+
+    # Handle '/c'  for dividing by the speed of light
+    nc = key.count("/c")
+    if nc > 0:
+        key = key.replace("/c", "")
+        u = pg_units(key)
+        for _ in range(nc):
+            u = u / unit("m") * unit("s")
+        return u
 
     if key.startswith("cov_"):
         subkeys = key.strip("cov_").split("__")

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -2,6 +2,7 @@ from pmd_beamphysics import ParticleGroup
 import pytest
 import numpy as np
 import os
+from scipy.constants import c
 
 P = ParticleGroup("docs/examples/data/bmad_particles.h5")
 
@@ -13,7 +14,7 @@ r theta pr ptheta
 Lz
 gamma beta beta_x beta_y beta_z
 x_bar px_bar Jx Jy
-charge
+weight
 
 """.split()
 
@@ -34,6 +35,11 @@ def array_key(request):
     return request.param
 
 
+@pytest.fixture(params=ARRAY_KEYS)
+def array_key2(request):
+    return request.param
+
+
 @pytest.fixture(params=OPERATORS)
 def operator(request):
     return request.param
@@ -42,6 +48,22 @@ def operator(request):
 def test_operator(operator, array_key):
     key = f"{operator}{array_key}"
     P[key]
+
+
+def test_operator_over_c(operator, array_key):
+    key0 = f"{operator}{array_key}"
+    key1 = f"{operator}{array_key}/c"
+    key2 = f"{operator}{array_key}/c/c"
+    assert np.allclose(P[key0] / c, P[key1])
+    assert np.allclose(P[key0] / c / c, P[key2])
+
+
+def test_cov_over_c(array_key, array_key2):
+    key0 = f"cov_{array_key}__{array_key2}"
+    key1 = f"cov_{array_key}/c__{array_key2}"
+    key2 = f"cov_{array_key}/c__{array_key2}/c"
+    assert np.allclose(P[key0] / c, P[key1])
+    assert np.allclose(P[key0] / c / c, P[key2])
 
 
 # This is probably uneccessary:

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -35,9 +35,7 @@ def array_key(request):
     return request.param
 
 
-@pytest.fixture(params=ARRAY_KEYS)
-def array_key2(request):
-    return request.param
+array_key2 = array_key
 
 
 @pytest.fixture(params=OPERATORS)

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -2,13 +2,13 @@ from pmd_beamphysics import ParticleGroup
 import pytest
 import numpy as np
 import os
-from scipy.constants import c
 
 P = ParticleGroup("docs/examples/data/bmad_particles.h5")
 
 
 ARRAY_KEYS = """
 x y z px py pz t status weight id
+z/c
 p energy kinetic_energy xp yp higher_order_energy
 r theta pr ptheta
 Lz
@@ -50,29 +50,9 @@ def test_operator(operator, array_key):
     P[key]
 
 
-def test_operator_over_c(operator, array_key):
-    key0 = f"{operator}{array_key}"
-    key1 = f"{operator}{array_key}/c"
-    key2 = f"{operator}{array_key}/c/c"
-    assert np.allclose(P[key0] / c, P[key1])
-    assert np.allclose(P[key0] / c / c, P[key2])
-
-
-def test_cov_over_c(array_key, array_key2):
-    key0 = f"cov_{array_key}__{array_key2}"
-    key1 = f"cov_{array_key}/c__{array_key2}"
-    key2 = f"cov_{array_key}/c__{array_key2}/c"
-    assert np.allclose(P[key0] / c, P[key1])
-    assert np.allclose(P[key0] / c / c, P[key2])
-
-
-# This is probably uneccessary:
-# @pytest.fixture(params=array_keys)
-# def array_key2(request):
-#     return request.param
-#
-# def test_cov(array_key, array_key2):
-#     P[f'cov_{array_key}__{array_key}']
+def test_cov_(array_key, array_key2):
+    key = f"cov_{array_key}__{array_key2}"
+    P[key]
 
 
 @pytest.fixture(params=SPECIAL_STATS)


### PR DESCRIPTION
This adds a new `z/c` key to divide by the speed of light. For example:

```
>>> P['sigma_z/c']
np.float64(2.4466662134476153e-14)
```

Units are correctly handled:
```
>>> P.units('sigma_z/c')
pmd_unit('s', 1, (0, 0, 1, 0, 0, 0, 0))
```

This is useful when particles are in t-coordinates, but you want to see a current profile in A:
<img width="648" alt="image" src="https://github.com/user-attachments/assets/0823cb41-5833-4098-864c-13417c7f7989">

This way the "head" is on the right. 
