### PR TITLE
FIX: np.float deprecated in 1.2 and removed in 2

### DIFF
--- a/pmd_beamphysics/interfaces/impact.py
+++ b/pmd_beamphysics/interfaces/impact.py
@@ -34,7 +34,7 @@ def parse_impact_particles(
 
     """
 
-    dtype = {"names": names, "formats": 6 * [np.float]}
+    dtype = {"names": names, "formats": 6 * [float]}
     pdat = np.loadtxt(
         filePath, skiprows=skiprows, dtype=dtype, ndmin=1
     )  # to make sure that 1 particle is parsed the same as many.


### PR DESCRIPTION
```python
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```