### PR TITLE
FIX: show a plot rather than crashing with single particles

### DIFF
--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -284,6 +284,8 @@ def marginal_plot(
     y = particle_group[key2]
 
     if len(x) == 1:
+        bins = 100
+
         if xlim is None:
             (x0,) = x
             if np.isclose(x0, 0.0):
@@ -296,10 +298,6 @@ def marginal_plot(
                 ylim = (-1, 1)
             else:
                 ylim = tuple(sorted((0.9 * y0, 1.1 * y0)))
-        bins = 100
-        gridsize = (bins, bins)
-    else:
-        gridsize = bins
 
     # Form nice arrays
     x, f1, p1, xmin, xmax = plottable_array(x, nice=nice, lim=xlim)
@@ -334,9 +332,18 @@ def marginal_plot(
 
     # Main plot
     # Proper weighting
-    ax_joint.hexbin(
-        x, y, C=w, reduce_C_function=np.sum, gridsize=gridsize, cmap=CMAP0, vmin=1e-20
-    )
+    if len(x) == 1:
+        ax_joint.scatter(x, y)
+    else:
+        ax_joint.hexbin(
+            x,
+            y,
+            C=w,
+            reduce_C_function=np.sum,
+            gridsize=bins,
+            cmap=CMAP0,
+            vmin=1e-20,
+        )
 
     if ellipse:
         sigma_mat2 = particle_group.cov(key1, key2)

--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -284,6 +284,18 @@ def marginal_plot(
     y = particle_group[key2]
 
     if len(x) == 1:
+        if xlim is None:
+            (x0,) = x
+            if np.isclose(x0, 0.0):
+                xlim = (-1, 1)
+            else:
+                xlim = tuple(sorted((0.9 * x0, 1.1 * x0)))
+        if ylim is None:
+            (y0,) = y
+            if np.isclose(y0, 0.0):
+                ylim = (-1, 1)
+            else:
+                ylim = tuple(sorted((0.9 * y0, 1.1 * y0)))
         gridsize = (1, 1)
         bins = 1
     else:
@@ -305,6 +317,12 @@ def marginal_plot(
     labely = mathlabel(key2, units=uy, tex=tex)
 
     fig = plt.figure(**kwargs)
+    if np.all(np.isnan(x)):
+        fig.text(0.5, 0.5, f"{key1} is all NaN", ha="center", va="center")
+        return fig
+    if np.all(np.isnan(y)):
+        fig.text(0.5, 0.5, f"{key2} is all NaN", ha="center", va="center")
+        return fig
 
     gs = GridSpec(4, 4)
 

--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -297,7 +297,7 @@ def marginal_plot(
             else:
                 ylim = tuple(sorted((0.9 * y0, 1.1 * y0)))
         gridsize = (1, 1)
-        bins = 1
+        bins = 100
     else:
         gridsize = bins
 

--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -283,6 +283,12 @@ def marginal_plot(
     x = particle_group[key1]
     y = particle_group[key2]
 
+    if len(x) == 1:
+        gridsize = (1, 1)
+        bins = 1
+    else:
+        gridsize = bins
+
     # Form nice arrays
     x, f1, p1, xmin, xmax = plottable_array(x, nice=nice, lim=xlim)
     y, f2, p2, ymin, ymax = plottable_array(y, nice=nice, lim=ylim)
@@ -311,7 +317,7 @@ def marginal_plot(
     # Main plot
     # Proper weighting
     ax_joint.hexbin(
-        x, y, C=w, reduce_C_function=np.sum, gridsize=bins, cmap=CMAP0, vmin=1e-20
+        x, y, C=w, reduce_C_function=np.sum, gridsize=gridsize, cmap=CMAP0, vmin=1e-20
     )
 
     if ellipse:

--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -296,8 +296,8 @@ def marginal_plot(
                 ylim = (-1, 1)
             else:
                 ylim = tuple(sorted((0.9 * y0, 1.1 * y0)))
-        gridsize = (1, 1)
         bins = 100
+        gridsize = (bins, bins)
     else:
         gridsize = bins
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import logging
+import pathlib
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import pytest
+
+mpl.use("Agg")
+
+test_root = pathlib.Path(__file__).resolve().parent
+repo_root = test_root.parent
+
+test_artifacts = test_root / "artifacts"
+test_artifacts.mkdir(exist_ok=True)
+
+logging.getLogger("matplotlib").setLevel("INFO")
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _plot_show_to_savefig(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    index = 0
+    node_name = request.node.name.replace("/", "_")
+
+    def savefig():
+        nonlocal index
+        filename = test_artifacts / f"{node_name}_{index}.png"
+        print(f"Saving figure (_plot_show_to_savefig fixture) to {filename}")
+        plt.savefig(filename)
+        index += 1
+
+    monkeypatch.setattr(plt, "show", savefig)

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -1,7 +1,11 @@
-from pmd_beamphysics import ParticleGroup
-import pytest
-import numpy as np
 import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from pmd_beamphysics import ParticleGroup
+from pmd_beamphysics.particles import single_particle
 
 P = ParticleGroup("docs/examples/data/bmad_particles.h5")
 
@@ -90,3 +94,14 @@ def test_write_reload(tmp_path):
 def test_fractional_split():
     head, tail = P.fractional_split(0.5, "t")
     head, core, tail = P.fractional_split((0.1, 0.9), "t")
+
+
+def test_plot_vs_z(array_key: str):
+    P.plot("z", array_key)
+    plt.show()
+
+
+def test_plot_single_particle_vs_z(array_key: str):
+    Ps = single_particle(pz=10e6)
+    Ps.plot("z", array_key)
+    plt.show()


### PR DESCRIPTION
## Changes

Show a plot rather than crashing when using plot functions on `ParticleGroup` instances holding a single particle.

These are not terribly useful plots, of course, but are better than a crash.

### Screenshots

Before

<img width="748" alt="image" src="https://github.com/user-attachments/assets/2410d875-66bd-4794-a836-b0c25e892cb6" />


After
<img width="964" alt="image" src="https://github.com/user-attachments/assets/d8dbe0df-00c9-4de2-923f-05cd2e7a257d" />
