### PR TITLE
ENH: `pmd_unit` hashability

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,12 +81,35 @@ plugins:
       default_handler: python
       handlers:
         python:
-          selection:
-            docstring_style: "numpy"
-            inherited_members: false
+          options:
             filters:
               - "!^_" # exclude all members starting with _
               - "^__init__$" # but always include __init__ modules and methods
+            docstring_style: numpy
+            docstring_options:
+              ignore_init_summary: false
+            heading_level: 3
+            show_root_heading: true
+            show_root_toc_entry: true
+            show_root_full_path: true
+            show_root_members_full_path: false
+            show_object_full_path: true
+            show_category_heading: true
+            show_if_no_docstring: false
+            show_signature: true
+            signature_crossrefs: true
+            show_signature_annotations: false
+            separate_signature: true
+            line_length: 100
+            merge_init_into_class: true
+            show_source: true
+            show_bases: true
+            show_submodules: false
+            group_by_category: true
+            unwrap_annotated: true
+            import:
+              - https://docs.python.org/3/objects.inv
+              - https://docs.h5py.org/en/stable/objects.inv
           rendering:
             show_source: true
             show_root_heading: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,3 @@ plugins:
             import:
               - https://docs.python.org/3/objects.inv
               - https://docs.h5py.org/en/stable/objects.inv
-          rendering:
-            show_source: true
-            show_root_heading: true

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -8,7 +8,7 @@ For more advanced units, use a package like Pint:
 from __future__ import annotations
 
 import re
-from typing import Sequence, TypeAlias
+from typing import Sequence
 
 import numpy as np
 import scipy.constants
@@ -20,8 +20,8 @@ e_charge = scipy.constants.e
 mu_0 = scipy.constants.mu_0  # Note that this is no longer 4pi*10^-7 !
 
 
-Limit: TypeAlias = tuple[float | None, float | None]
-Dimension: TypeAlias = tuple[int, int, int, int, int, int, int]
+Limit = tuple[float | None, float | None]
+Dimension = tuple[int, int, int, int, int, int, int]
 
 
 class pmd_unit:

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -8,7 +8,7 @@ For more advanced units, use a package like Pint:
 from __future__ import annotations
 
 import re
-from typing import Sequence
+from typing import Optional, Sequence
 
 import numpy as np
 import scipy.constants
@@ -20,7 +20,7 @@ e_charge = scipy.constants.e
 mu_0 = scipy.constants.mu_0  # Note that this is no longer 4pi*10^-7 !
 
 
-Limit = tuple[float | None, float | None]
+Limit = tuple[Optional[float], Optional[float]]
 Dimension = tuple[int, int, int, int, int, int, int]
 
 

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -72,6 +72,9 @@ class pmd_unit:
         else:
             self._unitDimension = unitDimension
 
+    def __hash__(self) -> int:
+        return hash((self.unitSymbol, self.unitSI, self.unitDimension))
+
     @property
     def unitSymbol(self):
         return self._unitSymbol

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -110,7 +110,7 @@ class pmd_unit:
         self._unitSymbol = unitSymbol
         self._unitSI = unitSI
         if isinstance(unitDimension, str):
-            self._unitDimension = DIMENSION[unitDimension]
+            self._unitDimension = dimension(unitDimension)
         else:
             self._unitDimension = make_dimension(unitDimension)
 
@@ -298,7 +298,13 @@ def make_dimension(dim: Sequence[int]) -> Dimension:
 
 
 def dimension(name: str) -> Dimension | None:
-    return DIMENSION.get(name, None)
+    try:
+        return DIMENSION[name]
+    except KeyError:
+        options = ", ".join(DIMENSION)
+        raise ValueError(
+            f"Invalid unit dimension string: {name}. Valid options are: {options}"
+        )
 
 
 def dimension_name(dim_array: Dimension) -> str:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+import numpy as np
+import pytest
+from pmd_beamphysics.units import (
+    SHORT_PREFIX_FACTOR,
+    dimension,
+    nice_array,
+    nice_scale_prefix,
+    plottable_array,
+    pmd_unit,
+    unit,
+)
+
+
+def test_smoke_properties() -> None:
+    u = unit("K")
+    u.unitSymbol
+    u.unitSI
+    u.unitDimension
+
+
+def test_equality() -> None:
+    assert pmd_unit("T") == pmd_unit("T")
+    assert pmd_unit("T") != pmd_unit("eV")
+    assert pmd_unit("T") != "foo"
+
+
+def test_hashability() -> None:
+    assert len({pmd_unit("T"), pmd_unit("eV"), pmd_unit("T")}) == 2
+
+
+def test_divide() -> None:
+    kg_over_g = pmd_unit("kg") / pmd_unit("g")
+    assert kg_over_g.unitDimension == (0,) * 7
+    assert kg_over_g.unitSI == 1000.0
+
+
+def test_multiply() -> None:
+    momentum = pmd_unit("kg") * pmd_unit("m") / pmd_unit("s")
+    assert momentum.unitDimension == dimension("momentum")
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected_unit"),
+    [
+        pytest.param("A*s", pmd_unit("A") * pmd_unit("s")),
+        pytest.param("A/s", pmd_unit("A") / pmd_unit("s")),
+        pytest.param("A/s/s", pmd_unit("A") / pmd_unit("s") / pmd_unit("s")),
+    ],
+)
+def test_unit(symbol: str, expected_unit: pmd_unit) -> None:
+    assert unit(symbol) == expected_unit
+
+
+@pytest.mark.parametrize(
+    ("prefix", "factor"),
+    [
+        pytest.param(prefix, factor, id=prefix)
+        for prefix, factor in SHORT_PREFIX_FACTOR.items()
+    ],
+)
+def test_smoke_nice_scale_prefix(prefix: str, factor: float) -> None:
+    res = nice_scale_prefix(factor)
+    print(f"{factor=} raw {prefix=} ->", res)
+
+
+@pytest.mark.parametrize(
+    ("value", "prefix", "factor"),
+    [
+        (1e-3, "m", 1e-3),
+        (1000.0, "k", 1000.0),
+        (1e6, "M", 1e6),
+        (1e9, "G", 1e9),
+        (1e25, "Y", 1e24),
+        (1e-25, "y", 1e-24),
+        (0.0, "", 1),
+    ],
+)
+def test_nice_scale_prefix(value: float, prefix: str, factor: float) -> None:
+    assert nice_scale_prefix(value) == (factor, prefix)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(1.0, (1.0, 1, "")),
+        pytest.param([1.0], (1.0, 1, "")),
+        pytest.param([1.0, 1.0, 1.0], (1.0, 1, "")),
+    ],
+)
+def test_nice_array(
+    value: float | list[float],
+    expected: tuple[np.ndarray | float, float, str],
+) -> None:
+    expected_scaled, expected_scaling, expected_prefix = expected
+    res_scaled, res_scaling, res_prefix = nice_array(value)
+    np.testing.assert_allclose(actual=res_scaled, desired=expected_scaled)
+    assert expected_scaling == res_scaling
+    assert res_prefix == expected_prefix
+
+
+@pytest.mark.parametrize(
+    ("value",),
+    [
+        pytest.param(1.0),
+        pytest.param([1.0]),
+        pytest.param([1.0, 1.0, 1.0]),
+    ],
+)
+def test_plottable_array_smoke(value: float | list[float]) -> None:
+    for lim, nice in [
+        (None, True),
+        (None, False),
+        ((-10, 10), False),
+        ((None, 10), False),
+        ((None, None), False),
+        ((-10, None), False),
+    ]:
+        res, *_ = plottable_array(value, lim=lim, nice=nice)
+        np.testing.assert_allclose(actual=res, desired=value)


### PR DESCRIPTION
## Changes

I set out to just make `pmd_unit` hashable, but got carried away with some clean-ups along the way.

* `pmd_unit` is now hashable. This means it can be used as a dictionary key or as an element of a set, for example.
* Bonus: added docstrings to some functions missing them
* Bonus: added some type hints and unit tests for `pmd_beamphysics.units`
* Bonus: added support for `*` and `/` operators of 2+ units with a couple simple tests
* Test coverage of `pmd_beamphysics.units` is now pretty good
* Fix mkdocs building after (likely) changes in mkdocstrings-python and our config. This may need to be propagated to other projects.