### PR TITLE
`ParticleGroup.from_random_normal()`

### DIFF
--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -227,8 +227,8 @@ class ParticleGroup:
     def from_random_normal(
         cls,
         n_particle: int,
-        mean: np.ndarray | None = None,
-        cov: np.ndarray | None = None,
+        mean: Union[np.ndarray, None] = None,
+        cov: Union[np.ndarray, None] = None,
         species: str = "electron",
         t_or_z: Literal["t", "z"] = "z",
     ) -> "ParticleGroup":

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -286,9 +286,11 @@ class ParticleGroup:
             species=species,
         )
         if t_or_z == "t":
-            data["t"] = samp[:4]
+            data["t"] = samp[:, 4]
+            data["z"] = np.zeros(n_particle)
         elif t_or_z == "z":
-            data["z"] = samp[:4]
+            data["t"] = np.zeros(n_particle)
+            data["z"] = samp[:, 4]
         else:
             raise ValueError(f"t_or_z must be either `t` or `z`. Got: {t_or_z}")
         return ParticleGroup(data=data)

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -293,7 +293,7 @@ class ParticleGroup:
             data["z"] = samp[:, 4]
         else:
             raise ValueError(f"t_or_z must be either `t` or `z`. Got: {t_or_z}")
-        return ParticleGroup(data=data)
+        return cls(data=data)
 
     # -------------------------------------------------
     # Access to intrinsic coordinates

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -266,8 +266,8 @@ class ParticleGroup:
             cov = np.zeros(6)
             cov[0] = cov[2] = 100e-6**2
             cov[1] = cov[3] = 10e3**2
-            cov[5] = 1e-3**2
-            cov[6] = 1e2**2
+            cov[4] = 1e-3**2
+            cov[5] = 1e2**2
         if len(cov.shape) == 1:
             cov = np.diag(cov)
 

--- a/pmd_beamphysics/particles.py
+++ b/pmd_beamphysics/particles.py
@@ -2,7 +2,7 @@ import functools
 import os
 import pathlib
 from copy import deepcopy
-from typing import Union
+from typing import Union, Literal
 
 import numpy as np
 from h5py import File
@@ -222,6 +222,76 @@ class ParticleGroup:
         self._settable_keys = self._settable_array_keys + self._settable_scalar_keys
         # Internal data. Only allow settable keys
         self._data = {k: data[k] for k in self._settable_keys}
+
+    @classmethod
+    def from_random_normal(
+        cls,
+        n_particle: int,
+        mean: np.ndarray | None = None,
+        cov: np.ndarray | None = None,
+        species: str = "electron",
+        t_or_z: Literal["t", "z"] = "z",
+    ) -> "ParticleGroup":
+        """
+        Generate beam from normal distribution specified from mean vector and covariance matrix.
+
+        Coordinates are ordered as [x, px, y, py, <see notes>, pz]
+
+        You have a choice of time-like coordinate by specifying `t_or_z`.
+
+        Parameters
+        ----------
+        n_particle : int
+            Number of particles to generate
+        mean : np.ndarray | None, optional
+            Mean vector (6d vector), by default None
+        cov : np.ndarray | None, optional
+            Covariance matrix (6x6 numpy array or 6d vector interpreted as the diagonal), by default None
+        species : str, optional
+            Which particle, by default 'electron'
+        t_or_z : Literal[&quot;t&quot;, &quot;z&quot;], optional
+            Which time-like coordinate to use, by default "z"
+
+        Returns
+        -------
+        ParticleGroup
+            The ParticleGroup object with generated samples
+        """
+        # Clean up input; process defaults
+        t_or_z = t_or_z.lower()
+        if mean is None:
+            mean = np.zeros(6)
+            mean[5] = 1e6
+        if cov is None:
+            cov = np.zeros(6)
+            cov[0] = cov[2] = 100e-6**2
+            cov[1] = cov[3] = 10e3**2
+            cov[5] = 1e-3**2
+            cov[6] = 1e2**2
+        if len(cov.shape) == 1:
+            cov = np.diag(cov)
+
+        # Create samples
+        samp = np.random.multivariate_normal(mean, cov, n_particle)
+
+        # Pack into object
+        data = dict(
+            x=samp[:, 0],
+            px=samp[:, 1],
+            y=samp[:, 2],
+            py=samp[:, 3],
+            pz=samp[:, 5],
+            status=np.ones(n_particle),
+            weight=np.ones(n_particle),
+            species=species,
+        )
+        if t_or_z == "t":
+            data["t"] = samp[:4]
+        elif t_or_z == "z":
+            data["z"] = samp[:4]
+        else:
+            raise ValueError(f"t_or_z must be either `t` or `z`. Got: {t_or_z}")
+        return ParticleGroup(data=data)
 
     # -------------------------------------------------
     # Access to intrinsic coordinates

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -121,7 +121,7 @@ def test_from_random_normal(t_or_z):
         ]
     )
 
-    # Test with z coordinates (default)
+    # Test
     np.random.seed(42)
     pg = ParticleGroup.from_random_normal(
         n_particle, mean=mean, cov=cov, species="electron", t_or_z=t_or_z
@@ -162,6 +162,25 @@ def test_from_random_normal(t_or_z):
         rtol=3e-1,
         atol=1e-3,
     )
+
+
+@pytest.mark.parametrize("t_or_z", ["t", "z"])
+def test_from_random_normal_default(t_or_z):
+    """Test ParticleGroup.from_random_normal with default parameters"""
+    n_particle = 500_000
+
+    # Test with z coordinates (default)
+    np.random.seed(42)
+    pg = ParticleGroup.from_random_normal(n_particle, t_or_z=t_or_z)
+
+    # Basic properties
+    assert len(pg) == n_particle
+    assert pg.species == "electron"
+    assert pg.n_particle == n_particle
+
+    # Check that all particles have status = 1 and weight = 1
+    assert np.all(pg.status == 1)
+    assert np.all(pg.weight == 1)
 
 
 @pytest.mark.filterwarnings("ignore:.*invalid value encountered in.*")

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -182,6 +182,21 @@ def test_from_random_normal_default(t_or_z):
     assert np.all(pg.status == 1)
     assert np.all(pg.weight == 1)
 
+    # Check the mean
+    measured_means = np.array(
+        [
+            pg.avg("x") / pg.std("x"),
+            pg.avg("px") / pg.std("px"),
+            pg.avg("y") / pg.std("y"),
+            pg.avg("py") / pg.std("py"),
+            pg.avg(t_or_z) / pg.std(t_or_z),
+            pg.avg("pz"),
+        ]
+    )
+    mean = np.zeros_like(measured_means)
+    mean[5] = 1e6
+    np.testing.assert_allclose(measured_means, mean, rtol=1e-2, atol=1e-2)
+
 
 @pytest.mark.filterwarnings("ignore:.*invalid value encountered in.*")
 @pytest.mark.filterwarnings("ignore:.*divide by zero.*")

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -101,6 +101,69 @@ def test_plot_vs_z(array_key: str):
     plt.show()
 
 
+@pytest.mark.parametrize("t_or_z", ["t", "z"])
+def test_from_random_normal(t_or_z):
+    """Test ParticleGroup.from_random_normal with explicit parameters"""
+    n_particle = 500_000
+
+    # Define explicit mean vector [x, px, y, py, z/t, pz]
+    mean = np.array([1e-3, 5e3, 2e-3, -3e3, 0.5, 1e6])
+
+    # Define explicit covariance matrix (6x6)
+    cov = np.array(
+        [
+            [100e-6**2, 10e-3, 0, 0, 0, 0],
+            [10e-3, 10e3**2, 0, 0, 0, 0],
+            [0, 0, 150e-6**2, 5e-9, 0, 0],
+            [0, 0, 5e-9, 15e3**2, 0, 0],
+            [0, 0, 0, 0, 1e-3**2, 0],
+            [0, 0, 0, 0, 0, 1e2**2],
+        ]
+    )
+
+    # Test with z coordinates (default)
+    np.random.seed(42)
+    pg = ParticleGroup.from_random_normal(
+        n_particle, mean=mean, cov=cov, species="electron", t_or_z=t_or_z
+    )
+
+    # Basic properties
+    assert len(pg) == n_particle
+    assert pg.species == "electron"
+    assert pg.n_particle == n_particle
+
+    # Check that all particles have status = 1 and weight = 1
+    assert np.all(pg.status == 1)
+    assert np.all(pg.weight == 1)
+
+    # Statistical tests - means should be close to specified values
+    measured_means = np.array(
+        [
+            pg.avg("x"),
+            pg.avg("px"),
+            pg.avg("y"),
+            pg.avg("py"),
+            pg.avg(t_or_z),
+            pg.avg("pz"),
+        ]
+    )
+    np.testing.assert_allclose(measured_means, mean, rtol=1e-2)
+
+    # Test covariance matrix - should be close to specified values
+    measured_cov = pg.cov("x", "px", "y", "py", t_or_z, "pz")
+    # Diagonal elements
+    np.testing.assert_allclose(np.diag(measured_cov), np.diag(cov), rtol=1e-2)
+    # Covariances (normalize by std. deviation)
+    np.testing.assert_allclose(
+        np.diag(measured_cov, 1)
+        / np.sqrt(np.diag(measured_cov))[:-1]
+        / np.sqrt(np.diag(measured_cov))[1:],
+        np.diag(cov, 1) / np.sqrt(np.diag(cov))[:-1] / np.sqrt(np.diag(cov))[1:],
+        rtol=3e-1,
+        atol=1e-3,
+    )
+
+
 @pytest.mark.filterwarnings("ignore:.*invalid value encountered in.*")
 @pytest.mark.filterwarnings("ignore:.*divide by zero.*")
 @pytest.mark.filterwarnings("ignore:.*Degrees of freedom.*")


### PR DESCRIPTION
Sometimes it is useful for testing/benchmarking to be able to create test distributions without manually building a `ParticleGroup` object yourself. This PR adds the new class method `ParticleGroup.from_random_normal()`. It can be called like this to get an object.

```bash
Python 3.13.3 | packaged by conda-forge | (main, Apr 14 2025, 20:44:30) [Clang 18.1.8 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pmd_beamphysics import ParticleGroup
>>> pg = ParticleGroup.from_random_normal(10000)
>>> len(pg)
10000
```

This returns a normally distributed beam with the requested number of particles. It also allows specifying the mean and covariance and also choosing which time-like coordinate is used.