### PR TITLE
Passing unit_symbol to prevent nonsense prefixes

### DIFF
--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -218,7 +218,7 @@
    "source": [
     "x = 1e-4\n",
     "unit = \"m\"\n",
-    "nice_array(x, unit_symbol=unit)"
+    "nice_array(x, unit)"
    ]
   },
   {
@@ -229,7 +229,7 @@
    },
    "outputs": [],
    "source": [
-    "nice_array([-0.01, 0.01])"
+    "nice_array([-0.01, 0.01], \"m\")"
    ]
   },
   {
@@ -251,7 +251,46 @@
    },
    "outputs": [],
    "source": [
-    "nice_scale_prefix(0.009, unit_symbol='m')"
+    "nice_scale_prefix(0.009)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prefixes are not applied to sqrt units\n",
+    "\n",
+    "When a unit involves a square root, the nice_array function will not add a prefix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Regular unit - gets a prefix\n",
+    "nice_array(1e-6, \"m\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sqrt unit - does NOT get a prefix\n",
+    "nice_array(1e-6, \"sqrt(m)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Another example with a different magnitude\n",
+    "nice_array(0.005, \"√(m)\")"
    ]
   },
   {
@@ -263,47 +302,6 @@
     "This is a simple class for use with this package. So even simple things like the example below will fail. \n",
     "\n",
     "For more advanced units, use a package like Pint: https://pint.readthedocs.io/\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Same for nice_array\n",
-    "import numpy as np\n",
-    "x = np.array([1e-6, 2e-6, 3e-6])\n",
-    "nice_array(x, unit_symbol='√m')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Sqrt unit suppresses prefix\n",
-    "nice_scale_prefix(1e-6, unit_symbol='√m')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Normal unit gets prefix\n",
-    "nice_scale_prefix(1e-6, unit_symbol='m')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Sqrt units\n",
-    "\n",
-    "For sqrt units like √m used in normalized coordinates, prefixes are automatically suppressed to avoid confusing notation:"
    ]
   },
   {

--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -218,7 +218,7 @@
    "source": [
     "x = 1e-4\n",
     "unit = \"m\"\n",
-    "nice_array(x)"
+    "nice_array(x, unit_symbol=unit)"
    ]
   },
   {
@@ -251,7 +251,7 @@
    },
    "outputs": [],
    "source": [
-    "nice_scale_prefix(0.009)"
+    "nice_scale_prefix(0.009, unit_symbol='m')"
    ]
   },
   {
@@ -263,6 +263,47 @@
     "This is a simple class for use with this package. So even simple things like the example below will fail. \n",
     "\n",
     "For more advanced units, use a package like Pint: https://pint.readthedocs.io/\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Same for nice_array\n",
+    "import numpy as np\n",
+    "x = np.array([1e-6, 2e-6, 3e-6])\n",
+    "nice_array(x, unit_symbol='√m')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sqrt unit suppresses prefix\n",
+    "nice_scale_prefix(1e-6, unit_symbol='√m')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normal unit gets prefix\n",
+    "nice_scale_prefix(1e-6, unit_symbol='m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sqrt units\n",
+    "\n",
+    "For sqrt units like √m used in normalized coordinates, prefixes are automatically suppressed to avoid confusing notation:"
    ]
   },
   {

--- a/pmd_beamphysics/labels.py
+++ b/pmd_beamphysics/labels.py
@@ -128,7 +128,7 @@ def texlabel(key: str):
 
     if key.startswith("bunching"):
         wavelength = parse_bunching_str(key)
-        x, _, prefix = nice_array(wavelength)
+        x, _, prefix = nice_array(wavelength, unit_symbol='m')
         return rf"\mathrm{{bunching~at}}~{x:.1f}~\mathrm{{ {prefix}m }}"
 
     return rf"\mathrm{{ {key} }}"

--- a/pmd_beamphysics/plot.py
+++ b/pmd_beamphysics/plot.py
@@ -202,11 +202,11 @@ def density_plot(
     hist_x = bin_edges[:-1] + np.diff(bin_edges) / 2
     hist_width = np.diff(bin_edges)
     # Unit for histogram is charge per unit of x-axis
-    hist_unit = f"C/{ux}" if u1.unitSymbol != "s" else "A"
+    hist_unit = f"C/{ux}" if u1 != "s" else "A"
     hist_y, hist_f, hist_prefix = nice_array(hist / hist_width, unit_symbol=hist_unit)
     ax.bar(hist_x, hist_y, hist_width, color="grey")
     # Special label for C/s = A
-    if u1.unitSymbol == "s":
+    if u1 == "s":
         _, hist_prefix = nice_scale_prefix(hist_f / f1, unit_symbol="A")
         ax.set_ylabel(f"{hist_prefix}A")
     else:
@@ -365,11 +365,11 @@ def marginal_plot(
     hist, bin_edges = np.histogram(x, bins=bins, weights=w)
     hist_x = bin_edges[:-1] + np.diff(bin_edges) / 2
     hist_width = np.diff(bin_edges)
-    hist_unit = f"C/{ux}" if u1.unitSymbol != "s" else "A"
+    hist_unit = f"C/{ux}" if u1 != "s" else "A"
     hist_y, hist_f, hist_prefix = nice_array(hist / hist_width, unit_symbol=hist_unit)
     ax_marg_x.bar(hist_x, hist_y, hist_width, color="gray")
     # Special label for C/s = A
-    if u1.unitSymbol == "s":
+    if u1 == "s":
         _, hist_prefix = nice_scale_prefix(hist_f / f1, unit_symbol="A")
         ax_marg_x.set_ylabel(f"{hist_prefix}A")
     else:
@@ -382,7 +382,7 @@ def marginal_plot(
     hist, bin_edges = np.histogram(y, bins=bins, weights=w)
     hist_x = bin_edges[:-1] + np.diff(bin_edges) / 2
     hist_width = np.diff(bin_edges)
-    hist_unit = f"C/{uy}" if u2.unitSymbol != "s" else "A"
+    hist_unit = f"C/{uy}" if u2 != "s" else "A"
     hist_y, hist_f, hist_prefix = nice_array(hist / hist_width, unit_symbol=hist_unit)
     ax_marg_y.barh(hist_x, hist_y, hist_width, color="gray")
     ax_marg_y.set_xlabel(f"{hist_prefix}" + mathlabel(f"C/{uy}"))  # Always use tex

--- a/pmd_beamphysics/units.py
+++ b/pmd_beamphysics/units.py
@@ -440,7 +440,7 @@ SHORT_PREFIX: dict[float, str] = dict((v, k) for k, v in SHORT_PREFIX_FACTOR.ite
 # Nice scaling
 
 
-def nice_scale_prefix(scale: float) -> tuple[float, str]:
+def nice_scale_prefix(scale: float, unit_symbol: str = None) -> tuple[float, str]:
     """
     Returns a nice factor and an SI prefix string.
 
@@ -448,6 +448,9 @@ def nice_scale_prefix(scale: float) -> tuple[float, str]:
     ----------
     scale : float
         The scale to be converted into a nice factor and SI prefix.
+    unit_symbol : str, optional
+        The unit symbol to check for special cases. If provided, prefixes
+        will be suppressed for units containing sqrt symbols (√, sqrt, \\sqrt).
 
     Returns
     -------
@@ -460,7 +463,15 @@ def nice_scale_prefix(scale: float) -> tuple[float, str]:
     --------
     >>> nice_scale_prefix(scale=2e-10)
     (1e-12, 'p')
+    
+    >>> nice_scale_prefix(scale=2e-10, unit_symbol='√m')
+    (1, '')
     """
+    
+    # Check if unit contains sqrt symbols - suppress prefixes for these
+    if unit_symbol is not None:
+        if 'sqrt' in unit_symbol.lower() or '√' in unit_symbol or '\\sqrt' in unit_symbol:
+            return 1, ""
 
     if scale == 0:
         return 1, ""
@@ -479,7 +490,7 @@ def nice_scale_prefix(scale: float) -> tuple[float, str]:
     return f, SHORT_PREFIX[f]
 
 
-def nice_array(a: np.ndarray) -> tuple[np.ndarray, float, str]:
+def nice_array(a: np.ndarray, unit_symbol: str = None) -> tuple[np.ndarray, float, str]:
     """
     Scale an input array and return the scaled array, the scaling factor, and the
     corresponding unit prefix.
@@ -488,6 +499,9 @@ def nice_array(a: np.ndarray) -> tuple[np.ndarray, float, str]:
     ----------
     a : array-like, or float
         Input array to be scaled.
+    unit_symbol : str, optional
+        The unit symbol to check for special cases. If provided, prefixes
+        may be suppressed for certain unit types (e.g., sqrt units).
 
     Returns
     -------
@@ -512,11 +526,11 @@ def nice_array(a: np.ndarray) -> tuple[np.ndarray, float, str]:
         a = np.asarray(a)
         x = max(np.ptp(a), abs(np.mean(a)))  # Account for tiny spread
 
-    fac, prefix = nice_scale_prefix(x)
+    fac, prefix = nice_scale_prefix(x, unit_symbol)
     return a / fac, fac, prefix
 
 
-def plottable_array(x: np.ndarray, nice: bool = True, lim: Limit | None = None):
+def plottable_array(x: np.ndarray, nice: bool = True, lim: Limit | None = None, unit_symbol: str = None):
     """
     Similar to nice_array, but also considers limits for plotting
 
@@ -525,7 +539,11 @@ def plottable_array(x: np.ndarray, nice: bool = True, lim: Limit | None = None):
     x: array-like
     nice: bool, default = True
         Scale array by some nice factor.
-    xlim: tuple, default = None
+    lim: tuple, default = None
+        Optional limits (min, max)
+    unit_symbol: str, optional
+        Unit symbol to check for special cases (e.g., sqrt). If provided,
+        prefixes may be suppressed for certain unit types.
 
     Returns
     -------
@@ -552,7 +570,7 @@ def plottable_array(x: np.ndarray, nice: bool = True, lim: Limit | None = None):
         xmax = x.max()
 
     if nice:
-        _, factor, p1 = nice_array([xmin, xmax])
+        _, factor, p1 = nice_array([xmin, xmax], unit_symbol)
     else:
         factor, p1 = 1, ""
 


### PR DESCRIPTION
`nice_scale_prefix()`, `nice_array()`, and `plottable_array()` now all optionally take a `unit_symbol` argument. This allows the detection of prefixes that don't make sense and prevents them from being used. Other code which calls these functions in the repo updated to reflect the change

Fixes #116

----

Basic test:
```
python -c "
from pmd_beamphysics.units import nice_scale_prefix

# Test the updated cases
print('Test: A (Ampere) unit should get prefix')
f, p = nice_scale_prefix(1e-6, unit_symbol='A')
print(f'  Result: factor={f}, prefix=\"{p}\"')

print('\nTest: √m unit should NOT get prefix')
f, p = nice_scale_prefix(1e-6, unit_symbol='√m')
print(f'  Result: factor={f}, prefix=\"{p}\"')

print('\nTest: m (meter) unit should get prefix')
f, p = nice_scale_prefix(1e-6, unit_symbol='m')
print(f'  Result: factor={f}, prefix=\"{p}\"')
"
```