### PR TITLE
MAINT: clean up usage of functools.wraps on methods + docs tweaks

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -8,7 +8,7 @@ inputs:
   python-version:
     description: "Conda environment Python version"
     required: false
-    default: "3.9"
+    default: "3.10"
   env_name:
     description: "Conda environment name to create"
     required: false

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -50,3 +50,7 @@ runs:
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Show conda packages
+      shell: bash -l {0}
+      run: |
+        mamba list

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,8 +54,8 @@ jobs:
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     name: Test Suite
     steps:

--- a/beamphysics/fields/fieldmesh.py
+++ b/beamphysics/fields/fieldmesh.py
@@ -22,7 +22,7 @@ from ..interfaces.impact import (
     create_impact_emfield_cartesian_ele,
     create_impact_solrf_ele,
     parse_impact_emfield_cartesian,
-    write_impact_emfield_cartesian as _write_impact_emfield_cartesian,
+    write_impact_emfield_cartesian,
 )
 from ..interfaces.superfish import read_superfish_t7, write_superfish_t7
 from ..plot import (
@@ -661,16 +661,15 @@ class FieldMesh:
         Writes Impact-T style 1Tv3.T7 file corresponding to
         the `111: EMfldCart` element.
 
+        The file will contain grid information for X, Y, and Z dimensions followed by field values.
+        The field values are stored as complex numbers in the format (real, imaginary).
+
         Parameters
         ----------
         filename : str
             Path to the file where the field data will be written.
-
         """
-
-        return _write_impact_emfield_cartesian(self, filename)
-
-    write_impact_emfield_cartesian.__doc__ = _write_impact_emfield_cartesian.__doc__
+        return write_impact_emfield_cartesian(self, filename)
 
     # Superfish
     def write_superfish(self, filePath, verbose=False):
@@ -680,10 +679,15 @@ class FieldMesh:
         For static fields, a Poisson T7 file is written.
 
         For dynamic (`harmonic /= 0`) fields, a Fish T7 file is written
+
+        If .is_static, a Poisson file is written. Otherwise a Fish file is written.
+
+        Parameters
+        ----------
+        filePath : str or pathlib.Path
+            Output file path.
         """
         return write_superfish_t7(self, filePath, verbose=verbose)
-
-    write_superfish.__doc__ = write_superfish_t7.__doc__
 
     @classmethod
     def from_ansys_ascii_3d(cls, *, efile=None, hfile=None, frequency=None):

--- a/beamphysics/fields/fieldmesh.py
+++ b/beamphysics/fields/fieldmesh.py
@@ -1,4 +1,3 @@
-import functools
 import os
 from copy import deepcopy
 
@@ -23,7 +22,7 @@ from ..interfaces.impact import (
     create_impact_emfield_cartesian_ele,
     create_impact_solrf_ele,
     parse_impact_emfield_cartesian,
-    write_impact_emfield_cartesian,
+    write_impact_emfield_cartesian as _write_impact_emfield_cartesian,
 )
 from ..interfaces.superfish import read_superfish_t7, write_superfish_t7
 from ..plot import (
@@ -572,7 +571,6 @@ class FieldMesh:
         else:
             raise NotImplementedError(f"Geometry {self.geometry} not implemented")
 
-    # @functools.wraps(plot_fieldmesh_cylindrical_1d)
     def plot_onaxis(self, *args, **kwargs):
         if self.geometry == "cylindrical":
             return plot_fieldmesh_cylindrical_1d(self, *args, **kwargs)
@@ -609,9 +607,10 @@ class FieldMesh:
 
         write_pmd_field(g, self.data, name=name)
 
-    @functools.wraps(write_astra_1d_fieldmap)
     def write_astra_1d(self, filePath):
         return write_astra_1d_fieldmap(self, filePath)
+
+    write_astra_1d.__doc__ = write_astra_1d_fieldmap.__doc__
 
     def to_astra_1d(self):
         z, fz = astra_1d_fieldmap_data(self)
@@ -621,13 +620,15 @@ class FieldMesh:
     def write_astra_3d(self, common_filePath, verbose=False):
         return write_astra_3d_fieldmaps(self, common_filePath)
 
-    @functools.wraps(create_impact_solrf_ele)
     def to_impact_solrf(self, *args, **kwargs):
         return create_impact_solrf_ele(self, *args, **kwargs)
 
-    @functools.wraps(create_impact_emfield_cartesian_ele)
+    to_impact_solrf.__doc__ = create_impact_solrf_ele.__doc__
+
     def to_impact_emfield_cartesian(self, *args, **kwargs):
         return create_impact_emfield_cartesian_ele(self, *args, **kwargs)
+
+    to_impact_emfield_cartesian.__doc__ = create_impact_emfield_cartesian_ele.__doc__
 
     def to_cylindrical(self):
         """
@@ -655,7 +656,6 @@ class FieldMesh:
             self, filePath, asci2gdf_bin=asci2gdf_bin, verbose=verbose
         )
 
-    @functools.wraps(write_impact_emfield_cartesian)
     def write_impact_emfield_cartesian(self, filename):
         """
         Writes Impact-T style 1Tv3.T7 file corresponding to
@@ -668,10 +668,11 @@ class FieldMesh:
 
         """
 
-        return write_impact_emfield_cartesian(self, filename)
+        return _write_impact_emfield_cartesian(self, filename)
+
+    write_impact_emfield_cartesian.__doc__ = _write_impact_emfield_cartesian.__doc__
 
     # Superfish
-    @functools.wraps(write_superfish_t7)
     def write_superfish(self, filePath, verbose=False):
         """
         Write a Superfish T7 file.
@@ -681,6 +682,8 @@ class FieldMesh:
         For dynamic (`harmonic /= 0`) fields, a Fish T7 file is written
         """
         return write_superfish_t7(self, filePath, verbose=verbose)
+
+    write_superfish.__doc__ = write_superfish_t7.__doc__
 
     @classmethod
     def from_ansys_ascii_3d(cls, *, efile=None, hfile=None, frequency=None):
@@ -774,7 +777,6 @@ class FieldMesh:
         return cls(data=dict(attrs=attrs, components=components))
 
     @classmethod
-    @functools.wraps(read_superfish_t7)
     def from_superfish(cls, filename, type=None, geometry="cylindrical"):
         """
         Class method to parse a superfish T7 style file.
@@ -782,6 +784,8 @@ class FieldMesh:
         data = read_superfish_t7(filename, type=type, geometry=geometry)
         c = cls(data=data)
         return c
+
+    from_superfish.__doc__ = read_superfish_t7.__doc__
 
     @classmethod
     def from_onaxis(
@@ -877,9 +881,10 @@ class FieldMesh:
         data = dict(attrs=attrs, components=components)
         return cls(data=data)
 
-    @functools.wraps(expand_fieldmesh_from_onaxis)
     def expand_onaxis(self, *args, **kwargs):
         return expand_fieldmesh_from_onaxis(self, *args, **kwargs)
+
+    expand_onaxis.__doc__ = expand_fieldmesh_from_onaxis.__doc__
 
     def __eq__(self, other):
         """

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import pathlib
 from copy import deepcopy
@@ -9,12 +8,12 @@ from h5py import File
 
 from . import statistics
 from .interfaces import bmad
-from .interfaces.astra import write_astra
+from .interfaces.astra import write_astra as _write_astra
 from .interfaces.elegant import write_elegant
 from .interfaces.genesis import (
     genesis2_beam_data,
     write_genesis2_beam_file,
-    write_genesis4_beam,
+    write_genesis4_beam as _write_genesis4_beam,
     write_genesis4_distribution,
 )
 from .interfaces.gpt import write_gpt
@@ -1041,12 +1040,12 @@ class ParticleGroup:
     # def __dict__(self):
     #    return self.data
 
-    @functools.wraps(bmad.particlegroup_to_bmad)
     def to_bmad(self, p0c=None, tref=None):
         return bmad.particlegroup_to_bmad(self, p0c=p0c, tref=tref)
 
+    to_bmad.__doc__ = bmad.particlegroup_to_bmad.__doc__
+
     @classmethod
-    @functools.wraps(bmad.bmad_to_particlegroup_data)
     def from_bmad(cls, bmad_dict):
         """
         Convert Bmad particle data as a dict
@@ -1076,12 +1075,15 @@ class ParticleGroup:
         data = bmad.bmad_to_particlegroup_data(bmad_dict)
         return cls(data=data)
 
+    from_bmad.__doc__ = bmad.bmad_to_particlegroup_data.__doc__
+
     # -------
     # Writers
 
-    @functools.wraps(write_astra)
     def write_astra(self, filePath, verbose=False, probe=False):
-        write_astra(self, filePath, verbose=verbose, probe=probe)
+        _write_astra(self, filePath, verbose=verbose, probe=probe)
+
+    write_astra.__doc__ = _write_astra.__doc__
 
     def write_bmad(self, filePath, p0c=None, t_ref=0, verbose=False):
         """
@@ -1131,7 +1133,6 @@ class ParticleGroup:
         # Actually write the file
         write_genesis2_beam_file(filePath, beam_columns, verbose=verbose)
 
-    @functools.wraps(write_genesis4_beam)
     def write_genesis4_beam(
         self, filePath, n_slice=None, return_input_str=False, verbose=False
     ):
@@ -1149,13 +1150,15 @@ class ParticleGroup:
         verbose : bool, optional
             If True, print information during writing. Default is False.
         """
-        return write_genesis4_beam(
+        return _write_genesis4_beam(
             self,
             filePath,
             n_slice=n_slice,
             return_input_str=return_input_str,
             verbose=verbose,
         )
+
+    write_genesis4_beam.__doc__ = _write_genesis4_beam.__doc__
 
     def write_genesis4_distribution(self, filePath, verbose=False):
         """
@@ -1755,10 +1758,11 @@ class ParticleGroup:
         """
         return deepcopy(self)
 
-    @functools.wraps(resample_particles)
     def resample(self, n=0, equal_weights=False):
         data = resample_particles(self, n, equal_weights=equal_weights)
         return ParticleGroup(data=data)
+
+    resample.__doc__ = resample_particles.__doc__
 
     # Internal sorting
     def _sort(self, key: str):

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -8,12 +8,12 @@ from h5py import File
 
 from . import statistics
 from .interfaces import bmad
-from .interfaces.astra import write_astra as _write_astra
+from .interfaces.astra import write_astra
 from .interfaces.elegant import write_elegant
 from .interfaces.genesis import (
     genesis2_beam_data,
     write_genesis2_beam_file,
-    write_genesis4_beam as _write_genesis4_beam,
+    write_genesis4_beam,
     write_genesis4_distribution,
 )
 from .interfaces.gpt import write_gpt
@@ -1041,32 +1041,50 @@ class ParticleGroup:
     #    return self.data
 
     def to_bmad(self, p0c=None, tref=None):
-        return bmad.particlegroup_to_bmad(self, p0c=p0c, tref=tref)
+        """
+        Convert to Bmad phase space coordinates.
 
-    to_bmad.__doc__ = bmad.particlegroup_to_bmad.__doc__
+        Bmad      openPMD-beamphysics
+        ----      -------------------
+        Bmad x  = x
+        Bmad px = px/p0c
+        Bmad y  = y
+        Bmad py = py/p0c
+        Bmad z = -beta * c * (t - tref)
+        Bmad pz = p/p0c - 1
+        Bmad t  = t
+
+        Parameters
+        ----------
+        p0c : float, optional
+            Reference momentum times the speed of light (in eV).
+            Default is None, which uses self['mean_p'].
+        tref : float, optional
+            Reference time (in seconds).
+            Default is None, which uses self['mean_t'].
+
+        Returns
+        -------
+        dict
+            A dictionary containing Bmad phase space coordinates.
+        """
+        return bmad.particlegroup_to_bmad(self, p0c=p0c, tref=tref)
 
     @classmethod
     def from_bmad(cls, bmad_dict):
         """
-        Convert Bmad particle data as a dict
-        to ParticleGroup data.
+        Convert Bmad particle data to a ParticleGroup.
 
-        See: ParticleGroup.to_bmad or particlegroup_to_bmad
+        This reverses the conversion done by to_bmad, mapping
+        Bmad phase space coordinates back to a ParticleGroup data format.
 
         Parameters
         ----------
-        bmad_data: dict
-            Dict with keys:
-            'x'
-            'px'
-            'y'
-            'py'
-            'z'
-            'pz',
-            'charge'
-            'species',
-            'tref'
-            'state'
+        bmad_dict : dict
+            A dictionary containing Bmad phase space coordinates
+            with keys:
+            'x', 'px', 'y', 'py', 'z', 'pz',
+            'charge', 'species', 'tref', 'state'
 
         Returns
         -------
@@ -1075,15 +1093,18 @@ class ParticleGroup:
         data = bmad.bmad_to_particlegroup_data(bmad_dict)
         return cls(data=data)
 
-    from_bmad.__doc__ = bmad.bmad_to_particlegroup_data.__doc__
-
     # -------
     # Writers
 
     def write_astra(self, filePath, verbose=False, probe=False):
-        _write_astra(self, filePath, verbose=verbose, probe=probe)
+        """
+        Write Astra style particles.
 
-    write_astra.__doc__ = _write_astra.__doc__
+        For now, the species must be electrons.
+
+        If probe, the six standard probe particles will be written.
+        """
+        write_astra(self, filePath, verbose=verbose, probe=probe)
 
     def write_bmad(self, filePath, p0c=None, t_ref=0, verbose=False):
         """
@@ -1150,15 +1171,13 @@ class ParticleGroup:
         verbose : bool, optional
             If True, print information during writing. Default is False.
         """
-        return _write_genesis4_beam(
+        return write_genesis4_beam(
             self,
             filePath,
             n_slice=n_slice,
             return_input_str=return_input_str,
             verbose=verbose,
         )
-
-    write_genesis4_beam.__doc__ = _write_genesis4_beam.__doc__
 
     def write_genesis4_distribution(self, filePath, verbose=False):
         """
@@ -1378,35 +1397,32 @@ class ParticleGroup:
 
         Parameters
         ----------
-        particle_group: ParticleGroup
-            The object to plot
-
-        key1: str, default = 't'
+        key1 : str, default = 't'
             Key to bin on the x-axis
 
-        key2: str, default = None
+        key2 : str, default = None
             Key to bin on the y-axis.
 
-        bins: int, default = None
+        bins : int, default = None
            Number of bins. If None, this will use a heuristic: bins = sqrt(n_particle/4)
 
-        xlim: tuple, default = None
+        xlim : tuple, default = None
             Manual setting of the x-axis limits. Note that these are in raw, unscaled units.
 
-        ylim: tuple, default = None
+        ylim : tuple, default = None
             Manual setting of the y-axis limits. Note that these are in raw, unscaled units.
 
-        tex: bool, default = True
+        tex : bool, default = True
             Use TEX for labels
 
-        nice: bool, default = True
+        nice : bool, default = True
             Scale to nice units
 
-        ellipse: bool, default = True
+        ellipse : bool, default = True
             If True, plot an ellipse representing the
             2x2 sigma matrix
 
-        return_figure: bool, default = False
+        return_figure : bool, default = False
             If true, return a matplotlib.figure.Figure object
 
         **kwargs
@@ -1759,10 +1775,35 @@ class ParticleGroup:
         return deepcopy(self)
 
     def resample(self, n=0, equal_weights=False):
+        """
+        Resample particles randomly.
+
+        If n equals self.n_particle or n=0,
+        particle indices will be scrambled.
+
+        Otherwise if weights are equal, a random subset of particles will be selected.
+
+        Otherwise if weights are not equal, particles will be sampled according
+        to their weight using
+        [scipy.stats.rv_discrete](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.html).
+        Note that this latter method can result in duplicate particles,
+        and can be very slow for a large number of particles.
+
+        Parameters
+        ----------
+        n : int, default=0
+            Number to resample.
+            If n=0, this will use all particles.
+
+        equal_weights : bool, default=False
+            If True, will ensure that all particles have equal weights.
+
+        Returns
+        -------
+        ParticleGroup
+        """
         data = resample_particles(self, n, equal_weights=equal_weights)
         return ParticleGroup(data=data)
-
-    resample.__doc__ = resample_particles.__doc__
 
     # Internal sorting
     def _sort(self, key: str):

--- a/beamphysics/statistics.py
+++ b/beamphysics/statistics.py
@@ -484,8 +484,8 @@ def resample_particles(particle_group, n=0, equal_weights=False):
 
     Otherwise if weights are equal, a random subset of particles will be selected.
 
-    Otherwise if weights are not equal, particles will be sampled according to their weight using a method from SciPy:
-    https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.html#scipy.stats.rv_discrete
+    Otherwise if weights are not equal, particles will be sampled according to their weight using
+    [scipy.stats.rv_discrete](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.html).
     Note that this latter method can result in duplicate particles, and can be very slow for a large number of particles.
 
     Parameters

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: beamphysics-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python>=3.10
   - numpy
   - scipy>=1.0.0
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,5 @@ dependencies:
   - mkdocs-jupyter
   - mkdocstrings-python
   - pygments
+  - pymdown-extensions >=10.21.2
   - pip

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,34 +94,34 @@ plugins:
 
   - mkdocs-jupyter:
       include_source: True
-
   - mkdocstrings:
-      default_handler: python
       handlers:
         python:
           options:
+            backlinks: tree
             docstring_options:
               ignore_init_summary: false
             docstring_style: numpy
-            filters:
-              - "!^_" # exclude all members starting with _
-              - "^__init__$" # but always include __init__ modules and methods
-            group_by_category: true
-            heading_level: 3
+            docstring_section_style: list
+            filters: public
+            heading_level: 2
+            inherited_members: true
             line_length: 100
             merge_init_into_class: true
+            parameter_headings: false
+            relative_crossrefs: true
+            scoped_crossrefs: true
             separate_signature: true
             show_bases: true
-            show_category_heading: true
-            show_if_no_docstring: false
-            show_object_full_path: true
-            show_root_full_path: true
+            show_inheritance_diagram: true
+            show_root_full_path: false
             show_root_heading: true
-            show_root_members_full_path: false
-            show_root_toc_entry: true
-            show_signature: true
-            show_signature_annotations: false
+            show_signature_annotations: true
+            show_signature_type_parameters: true
             show_source: true
-            show_submodules: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
+            summary: true
+            type_parameter_headings: true
             unwrap_annotated: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,28 +100,28 @@ plugins:
       handlers:
         python:
           options:
+            docstring_options:
+              ignore_init_summary: false
+            docstring_style: numpy
             filters:
               - "!^_" # exclude all members starting with _
               - "^__init__$" # but always include __init__ modules and methods
-            docstring_style: numpy
-            docstring_options:
-              ignore_init_summary: false
+            group_by_category: true
             heading_level: 3
-            show_root_heading: true
-            show_root_toc_entry: true
-            show_root_full_path: true
-            show_root_members_full_path: false
-            show_object_full_path: true
-            show_category_heading: true
-            show_if_no_docstring: false
-            show_signature: true
-            signature_crossrefs: true
-            show_signature_annotations: false
-            separate_signature: true
             line_length: 100
             merge_init_into_class: true
-            show_source: true
+            separate_signature: true
             show_bases: true
+            show_category_heading: true
+            show_if_no_docstring: false
+            show_object_full_path: true
+            show_root_full_path: true
+            show_root_heading: true
+            show_root_members_full_path: false
+            show_root_toc_entry: true
+            show_signature: true
+            show_signature_annotations: false
+            show_source: true
             show_submodules: false
-            group_by_category: true
+            signature_crossrefs: true
             unwrap_annotated: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 keywords = []
 name = "openpmd-beamphysics"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "pytest-benchmark", "pyyaml"]


### PR DESCRIPTION
### Changes

* Using `functools.wraps` on methods breaks the type checker, because of `self` in the method and the lack of it in the wrapped function (as used in the beamphysics package, at least)
* Initially I switched this to just applying `__doc__`, but gave it some more thought and copied over and fixed docstrings where needed instead

As a bit of a bonus:
* Looking at the generated docs, they are a bit lackluster currently. The mkdocstrings-python GitHub pages reminded me that it could look better: [see here](https://mkdocstrings.github.io/python/reference/api/).
* Small changes, really: show `attr`/`meth` next to items to show if they're attributes or methods. Add class inheritance diagrams.
* This can be reverted, but I think it looks nicer.
* The library is now 3.10+, as 3.9 is unsupported (and we're missing a conda-forge dep on 3.9)

### Screenshots

Before:
<img width="1269" height="831" alt="image" src="https://github.com/user-attachments/assets/1652315c-c41b-48a6-af19-36a2a69f03e4" />
After:
<img width="1314" height="864" alt="image" src="https://github.com/user-attachments/assets/0369718d-8774-4454-8e05-32de1397c10c" />

