### PR TITLE
PERF: lazy imports at the top-level

### DIFF
--- a/beamphysics/__init__.py
+++ b/beamphysics/__init__.py
@@ -1,14 +1,31 @@
-from .fields import FieldMesh
-from .particles import ParticleGroup, single_particle
-from .readers import particle_paths
-from .status import ParticleStatus
-from .wavefront import Wavefront, WavefrontK
-from .writers import pmd_init
+from __future__ import annotations
+
+import typing as _typing
+
+if _typing.TYPE_CHECKING:
+    from .fields import FieldMesh
+    from .particles import ParticleGroup, single_particle
+    from .readers import particle_paths
+    from .status import ParticleStatus
+    from .wavefront import Wavefront, WavefrontK
+    from .writers import pmd_init
 
 try:
     from ._version import __version__
 except ImportError:
     __version__ = "0.0.0"
+
+
+_LAZY_IMPORTS = {
+    "FieldMesh": ".fields",
+    "ParticleGroup": ".particles",
+    "single_particle": ".particles",
+    "particle_paths": ".readers",
+    "ParticleStatus": ".status",
+    "Wavefront": ".wavefront",
+    "WavefrontK": ".wavefront",
+    "pmd_init": ".writers",
+}
 
 
 __all__ = [
@@ -21,3 +38,21 @@ __all__ = [
     "Wavefront",
     "WavefrontK",
 ]
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name], package=__name__)
+
+        obj = getattr(module, name)
+
+        globals()[name] = obj
+        return obj
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(__all__))

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,19 @@
+import pytest
+
+import beamphysics
+
+LAZY_ATTRIBUTES: list[str] = list(beamphysics._LAZY_IMPORTS.keys())
+
+
+@pytest.mark.parametrize("attribute_name", LAZY_ATTRIBUTES, ids=LAZY_ATTRIBUTES)
+def test_lazy_imports_resolve_correctly(attribute_name: str) -> None:
+    resolved_object = getattr(beamphysics, attribute_name)
+    assert resolved_object is not None
+    assert attribute_name in beamphysics.__dir__()
+
+
+def test_lazy_import_invalid_attribute_raises_error() -> None:
+    with pytest.raises(AttributeError) as exc_info:
+        getattr(beamphysics, "bad_attr")
+
+    assert "bad_attr" in str(exc_info.value)


### PR DESCRIPTION
## Background

`beamphysics` currently takes almost 1 second to import on my machine.
The majority of that time is spent importing `scipy` and `matplotlib`, which are from nested imports in the library.

Until the user actually needs other bits of beamphysics, lazy importing is the way to go.

### Changes

That is what this PR implements:

1. For type checking, there's a block at the top that allows pyright/pylance (VS Code) to see what's in the module
2. For access of those items, `__getattr__` handles the imports dynamically. The first import incurs a cost, but subsequent imports are cached automatically (via `globals()` patching)
3. `__dir__` is a bit of an extra bit not truly required, but it's supported by the module interface, and should show everything that is/would be imported

While a bit more complicated than the main branch, this shouldn't be so complicated to update with future top-level imports.

## Performance

<img width="2400" height="1800" alt="import_times-log" src="https://github.com/user-attachments/assets/5c6b6c01-284e-4059-af64-3aaea0fd16f8" />

Yes, that's less than a millisecond for just the import.
Our commonly-used `beamphysics.units` takes much less time, too:

<img width="2400" height="1800" alt="import_times-units" src="https://github.com/user-attachments/assets/51c7b747-6e73-47ba-afe6-61b9cd058797" />

(Sorry, I switched scales there. I think the point still stands)

## What's next?

I'm onto distgen next, as it takes over a second to import thanks to `pint`!