### PR TITLE
Overhaul `pmd_unit` — expand named units, harden parser, value-based equality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+tests/artifacts/
 htmlcov/
 .tox/
 .coverage

--- a/beamphysics/interfaces/genesis.py
+++ b/beamphysics/interfaces/genesis.py
@@ -4,7 +4,7 @@ import numpy as np
 from h5py import File, Group
 
 from ..statistics import twiss_calc
-from ..units import Z0, c_light, mec2, unit, write_unit_h5
+from ..units import Z0, c_light, mec2, pmd_unit, write_unit_h5
 
 # Genesis 1.3
 # -------------
@@ -276,14 +276,14 @@ def genesis4_beam_data(pg, n_slice=None):
         if g2key not in g2data:
             continue
         data[g4key] = g2data[g2key]
-        units[g4key] = unit(u)
+        units[g4key] = pmd_unit(u)
 
     # Re-calculate these
     data["betax"] = data["gamma"] * data.pop("sigma_x") ** 2 / data["ex"]
     data["betay"] = data["gamma"] * data.pop("sigma_y") ** 2 / data["ey"]
 
-    units["betax"] = unit("m")
-    units["betay"] = unit("m")
+    units["betax"] = pmd_unit("m")
+    units["betay"] = pmd_unit("m")
 
     if "s" in data:
         data["s"] -= data["s"].min()

--- a/beamphysics/labels.py
+++ b/beamphysics/labels.py
@@ -1,4 +1,4 @@
-from .units import nice_array, parse_bunching_str
+from .units import nice_array, parse_bunching_str, pmd_unit
 
 TEXLABEL = {
     # 'status'
@@ -163,19 +163,29 @@ def mathlabel(*keys, units=None, tex=True):
     --------
         mathlabel('x_bar', 'sigma_x', units='µC')
         returns:
-        '$\\overline{x}, \\sigma_{ x }~(\\mathrm{ µC } )$'
+        '$\\overline{x}, \\sigma_{ x }~(\\mathrm{µC})$'
 
     """
-    # Cast to str
-    if units:
-        units = str(units)
+    # Translate units to a TeX fragment up front. For a pmd_unit, route
+    # through ``to_tex`` so compound symbols (eV/c, kg*m/s, sqrt(m), m^2)
+    # render correctly. For a str, try to parse it the same way; if it
+    # isn't a parseable unit symbol, fall back to wrapping the raw string
+    # in \mathrm{...}.
+    units_tex: str | None = None
+    if units is not None and units != "":
+        if isinstance(units, pmd_unit):
+            units_tex = units.to_tex()
+        else:
+            try:
+                units_tex = pmd_unit(str(units)).to_tex()
+            except (ValueError, KeyError):
+                units_tex = rf"\mathrm{{ {units} }}"
 
     if tex:
         label_list = [texlabel(key) or rf"\mathrm{{ {key} }}" for key in keys]
         label = ", ".join(label_list)
-        if units:
-            units = units.replace("*", r"{\cdot}")
-            label = rf"{label}~(\mathrm{{ {units} }} )"
+        if units_tex:
+            label = rf"{label}~({units_tex})"
 
         return rf"${label}$"
 

--- a/beamphysics/labels.py
+++ b/beamphysics/labels.py
@@ -179,7 +179,8 @@ def mathlabel(*keys, units=None, tex=True):
             try:
                 units_tex = pmd_unit(str(units)).to_tex()
             except (ValueError, KeyError):
-                units_tex = rf"\mathrm{{ {units} }}"
+                fallback = str(units).replace("*", r"{\cdot}")
+                units_tex = rf"\mathrm{{ {fallback} }}"
 
     if tex:
         label_list = [texlabel(key) or rf"\mathrm{{ {key} }}" for key in keys]
@@ -192,7 +193,10 @@ def mathlabel(*keys, units=None, tex=True):
     else:
         label = ", ".join(keys)
 
-        if units:
-            label = rf"{label} ({units})"
+        # Compare via str(): a pmd_unit object is always truthy, but a
+        # dimensionless unit has an empty symbol and should add no "()".
+        units_str = "" if units is None else str(units)
+        if units_str:
+            label = rf"{label} ({units_str})"
 
         return label

--- a/beamphysics/labels.py
+++ b/beamphysics/labels.py
@@ -80,8 +80,9 @@ def texlabel(key: str):
 
     Returns
     -------
-    tex: str or None
-        A TeX string if applicable, otherwise will return None
+    tex: str
+        A TeX fragment: a curated label when the key is known, otherwise
+        the key itself wrapped in ``\\mathrm{...}``.
 
 
     Examples
@@ -113,6 +114,8 @@ def texlabel(key: str):
                 return rf"\left|{tex0}\right|"
             if prefix in ("min", "max"):
                 return f"\\{prefix}({tex0})"
+            if prefix == "ptp":
+                return rf"\mathrm{{ptp}}({tex0})"
             if prefix == "sigma":
                 return rf"\sigma_{{ {tex0} }}"
             if prefix == "delta":
@@ -136,10 +139,10 @@ def texlabel(key: str):
 
 def mathlabel(*keys, units=None, tex=True):
     """
-    Helper function to return label with optional units
-    from an arbitrary number of keys
+    Axis/legend label for one or more attribute keys, with optional units.
 
-
+    With no keys, the label is the units alone — useful for axes that show
+    a bare quantity of known units, like the marginal histograms.
 
     Parameters
     ----------
@@ -147,7 +150,11 @@ def mathlabel(*keys, units=None, tex=True):
         any beamphysics attributes
 
     units : pmd_unit or str or None
-        units to be cast to str.
+        Units to append in parentheses. A ``pmd_unit``, or a string that
+        parses as a unit symbol, renders via ``pmd_unit.to_tex()`` (so
+        compound symbols like eV/c, sqrt(m), m^2, and parenthesized groups
+        come out right); any other string is shown as-is, with ``*`` as a
+        dot.
 
     tex : bool, default=True
         if True, a mathtext (TeX) string wrapped in $$ will be returned.
@@ -156,7 +163,7 @@ def mathlabel(*keys, units=None, tex=True):
     Returns
     -------
     label: str
-        A TeX string if applicable, otherwise will return None
+        A mathtext string when ``tex`` is True, otherwise a plain-text label.
 
 
     Examples
@@ -165,38 +172,38 @@ def mathlabel(*keys, units=None, tex=True):
         returns:
         '$\\overline{x}, \\sigma_{ x }~(\\mathrm{µC})$'
 
+        mathlabel(units='fC/µm')
+        returns:
+        '$\\mathrm{fC}/\\mathrm{µm}$'
+
     """
-    # Translate units to a TeX fragment up front. For a pmd_unit, route
-    # through ``to_tex`` so compound symbols (eV/c, kg*m/s, sqrt(m), m^2)
-    # render correctly. For a str, try to parse it the same way; if it
-    # isn't a parseable unit symbol, fall back to wrapping the raw string
-    # in \mathrm{...}.
-    units_tex: str | None = None
-    if units is not None and units != "":
-        if isinstance(units, pmd_unit):
-            units_tex = units.to_tex()
-        else:
-            try:
-                units_tex = pmd_unit(str(units)).to_tex()
-            except (ValueError, KeyError):
-                fallback = str(units).replace("*", r"{\cdot}")
-                units_tex = rf"\mathrm{{ {fallback} }}"
-
-    if tex:
-        label_list = [texlabel(key) or rf"\mathrm{{ {key} }}" for key in keys]
-        label = ", ".join(label_list)
-        if units_tex:
-            label = rf"{label}~({units_tex})"
-
-        return rf"${label}$"
-
-    else:
-        label = ", ".join(keys)
-
+    if not tex:
         # Compare via str(): a pmd_unit object is always truthy, but a
         # dimensionless unit has an empty symbol and should add no "()".
         units_str = "" if units is None else str(units)
+        if not keys:
+            return units_str
+        label = ", ".join(keys)
         if units_str:
             label = rf"{label} ({units_str})"
-
         return label
+
+    # Units -> TeX fragment ('' when there are none).
+    if units is None or str(units) == "":
+        units_frag = ""
+    elif isinstance(units, pmd_unit):
+        units_frag = units.to_tex()
+    else:
+        try:
+            units_frag = pmd_unit(str(units)).to_tex()
+        except (ValueError, KeyError):
+            fallback = str(units).replace("*", r"{\cdot}")
+            units_frag = rf"\mathrm{{ {fallback} }}"
+
+    if not keys:
+        return rf"${units_frag}$" if units_frag else ""
+
+    label = ", ".join(texlabel(key) for key in keys)
+    if units_frag:
+        label = rf"{label}~({units_frag})"
+    return rf"${label}$"

--- a/beamphysics/plot.py
+++ b/beamphysics/plot.py
@@ -22,6 +22,7 @@ from .units import (
     nice_scale_prefix,
     pg_units,
     plottable_array,
+    plottable_array_and_units,
     pmd_unit,
 )
 
@@ -29,6 +30,32 @@ CMAP0 = copy(plt.get_cmap("viridis"))
 CMAP0.set_under("white")
 
 CMAP1 = copy(plt.get_cmap("plasma"))
+
+
+def _charge_density_units_str(
+    x_unit, axis_units, hist_f: float, axis_f: float = 1.0
+) -> str:
+    """
+    Units string for a histogram density: charge per displayed axis unit.
+
+    The denominator is the axis unit exactly as the axis label shows it,
+    prefix included, and the histogram's own scale becomes a prefix on the
+    C: 'nC/µm', 'pC/(keV/c)'. A time axis is special-cased to amps
+    (C/s = A), which folds the histogram and axis scales into one prefix.
+
+    ``x_unit`` is the coordinate's pmd_unit, ``axis_units`` its displayed
+    label string, ``hist_f`` the factor the density values were divided by,
+    and ``axis_f`` the factor the coordinate was divided by.
+    """
+    if (pmd_unit("C") / x_unit).simplify() == pmd_unit("A"):
+        return pmd_unit("A").scaled_symbol(hist_f / axis_f)
+
+    numerator = pmd_unit("C").scaled_symbol(hist_f)
+    try:
+        return (pmd_unit(numerator) / pmd_unit(str(axis_units))).unitSymbol
+    except (ValueError, KeyError):
+        # Axis units in the explicit power-of-ten form ('1e-3 sqrt(m)').
+        return f"{numerator}/({axis_units})"
 
 
 def plt_histogram(a, weights=None, bins=40):
@@ -104,7 +131,6 @@ def slice_plot(
         has_delta_prefix = False
 
     # Get all data
-    x_key = "mean_" + slice_key
     slice_dat = particle_group.slice_statistics(
         *keys, n_slice=n_slice, slice_key=slice_key
     )
@@ -117,22 +143,25 @@ def slice_plot(
         x -= particle_group["mean_" + slice_key]
         slice_key = "delta_" + slice_key  # restore
 
-    x, f1, p1, xmin, xmax = plottable_array(x, nice=nice, lim=xlim)
-    ux = p1 + str(particle_group.units(slice_key))
+    x, f1, ux, xmin, xmax = plottable_array_and_units(
+        x, particle_group.units(slice_key), nice=nice, lim=xlim
+    )
 
     # Y-axis
 
-    # Units check
-    ulist = [particle_group.units(k).unitSymbol for k in keys]
-    uy = ulist[0]
-    if not all([u == uy for u in ulist]):
-        raise ValueError(f"Incompatible units: {ulist}")
+    # Units check (value-based: 'Hz' == '1/s')
+    ulist = [particle_group.units(k) for k in keys]
+    u0 = ulist[0]
+    if not all(u == u0 for u in ulist):
+        raise ValueError(f"Incompatible units: {[u.unitSymbol for u in ulist]}")
+    uy = u0.unitSymbol
 
     ymin = max([slice_dat[k].min() for k in keys])
     ymax = max([slice_dat[k].max() for k in keys])
 
-    _, f2, p2, ymin, ymax = plottable_array(np.array([ymin, ymax]), nice=nice, lim=ylim)
-    uy = p2 + uy
+    _, f2, uy, ymin, ymax = plottable_array_and_units(
+        np.array([ymin, ymax]), uy, nice=nice, lim=ylim
+    )
 
     # Form Figure
     fig, ax = plt.subplots(**kwargs)
@@ -150,13 +179,11 @@ def slice_plot(
         ax.legend()
 
     # Density on r.h.s
-    y2, _, prey2, _, _ = plottable_array(slice_dat[y2_key], nice=nice, lim=None)
+    y2, fy2, _, _, _ = plottable_array(slice_dat[y2_key], nice=nice, lim=None)
 
-    # Convert to Amps if possible
-    y2_units = f"C/{particle_group.units(x_key)}"
-    if y2_units == "C/s":
-        y2_units = "A"
-    y2_units = prey2 + y2_units
+    # Charge per (unprefixed) slice coordinate; a time axis displays as amps
+    slice_unit = particle_group.units(slice_key)
+    y2_units = _charge_density_units_str(slice_unit, slice_unit, fy2)
 
     # Labels
     labelx = mathlabel(slice_key, units=ux, tex=tex)
@@ -235,10 +262,10 @@ def density_plot(
         n = len(particle_group)
         bins = int(n / 100)
 
-    x, f1, p1, xmin, xmax = plottable_array(particle_group[key], nice=nice, lim=xlim)
+    x, f1, ux, xmin, xmax = plottable_array_and_units(
+        particle_group[key], particle_group.units(key), nice=nice, lim=xlim
+    )
     w = particle_group["weight"]
-    u1 = particle_group.units(key).unitSymbol
-    ux = p1 + u1
 
     labelx = mathlabel(key, units=ux, tex=tex)
 
@@ -250,17 +277,14 @@ def density_plot(
     hist, bin_edges = np.histogram(x, bins=bins, weights=w)
     hist_x = bin_edges[:-1] + np.diff(bin_edges) / 2
     hist_width = np.diff(bin_edges)
-    hist_y, hist_f, hist_prefix, _hist_xmin, _hist_xmax = plottable_array(
+    hist_y, hist_f, _, _hist_xmin, _hist_xmax = plottable_array(
         hist / hist_width, nice=nice
     )
 
     ax.bar(hist_x, hist_y, hist_width, color=color, alpha=alpha)
 
-    if u1 == "s":
-        _, hist_prefix = nice_scale_prefix(hist_f / f1)
-        ax.set_ylabel(f" density ({hist_prefix}A)")
-    else:
-        ax.set_ylabel(f"{hist_prefix}C/{ux}")
+    density_units = _charge_density_units_str(particle_group.units(key), ux, hist_f, f1)
+    ax.set_ylabel(f"density ({density_units})")
 
     if hasattr(ax, "get_shared_x_axes") and ax.get_shared_x_axes().joined(
         ax, ax.figure.axes[0]
@@ -355,16 +379,15 @@ def marginal_plot(
             else:
                 ylim = tuple(sorted((0.9 * y0, 1.1 * y0)))
 
-    # Form nice arrays
-    x, f1, p1, xmin, xmax = plottable_array(x, nice=nice, lim=xlim)
-    y, f2, p2, ymin, ymax = plottable_array(y, nice=nice, lim=ylim)
+    # Form nice arrays with display units
+    x, f1, ux, xmin, xmax = plottable_array_and_units(
+        x, particle_group.units(key1), nice=nice, lim=xlim
+    )
+    y, f2, uy, ymin, ymax = plottable_array_and_units(
+        y, particle_group.units(key2), nice=nice, lim=ylim
+    )
 
     w = particle_group["weight"]
-
-    u1 = particle_group.units(key1).unitSymbol
-    u2 = particle_group.units(key2).unitSymbol
-    ux = p1 + u1
-    uy = p2 + u2
 
     # Handle labels.
     labelx = mathlabel(key1, units=ux, tex=tex)
@@ -420,14 +443,12 @@ def marginal_plot(
     hist, bin_edges = np.histogram(x, bins=bins, weights=w)
     hist_x = bin_edges[:-1] + np.diff(bin_edges) / 2
     hist_width = np.diff(bin_edges)
-    hist_y, hist_f, hist_prefix = nice_array(hist / hist_width)
+    hist_y, hist_f, _ = nice_array(hist / hist_width)
     ax_marg_x.bar(hist_x, hist_y, hist_width, color="gray")
-    # Special label for C/s = A
-    if u1 == "s":
-        _, hist_prefix = nice_scale_prefix(hist_f / f1)
-        ax_marg_x.set_ylabel(f"{hist_prefix}A")
-    else:
-        ax_marg_x.set_ylabel(f"{hist_prefix}" + mathlabel(f"C/{ux}"))  # Always use tex
+    density_units = _charge_density_units_str(
+        particle_group.units(key1), ux, hist_f, f1
+    )
+    ax_marg_x.set_ylabel(mathlabel(units=density_units, tex=tex))
 
     # Side histogram
     # Old method:
@@ -436,9 +457,12 @@ def marginal_plot(
     hist, bin_edges = np.histogram(y, bins=bins, weights=w)
     hist_x = bin_edges[:-1] + np.diff(bin_edges) / 2
     hist_width = np.diff(bin_edges)
-    hist_y, hist_f, hist_prefix = nice_array(hist / hist_width)
+    hist_y, hist_f, _ = nice_array(hist / hist_width)
     ax_marg_y.barh(hist_x, hist_y, hist_width, color="gray")
-    ax_marg_y.set_xlabel(f"{hist_prefix}" + mathlabel(f"C/{uy}"))  # Always use tex
+    density_units = _charge_density_units_str(
+        particle_group.units(key2), uy, hist_f, f2
+    )
+    ax_marg_y.set_xlabel(mathlabel(units=density_units, tex=tex))
 
     # Turn off tick labels on marginals
     plt.setp(ax_marg_x.get_xticklabels(), visible=False)
@@ -479,14 +503,13 @@ def density_and_slice_plot(
     """
 
     # Scale to nice units and get the factor, unit prefix
-    x, f1, p1, xmin, xmax = plottable_array(particle_group[key1])
-    y, f2, p2, ymin, ymax = plottable_array(particle_group[key2])
+    x, f1, ux, xmin, xmax = plottable_array_and_units(
+        particle_group[key1], particle_group.units(key1)
+    )
+    y, f2, uy, ymin, ymax = plottable_array_and_units(
+        particle_group[key2], particle_group.units(key2)
+    )
     w = particle_group["weight"]
-
-    u1 = particle_group.units(key1).unitSymbol
-    u2 = particle_group.units(key2).unitSymbol
-    ux = p1 + u1
-    uy = p2 + u2
 
     labelx = mathlabel(key1, units=ux, tex=tex)
     labely = mathlabel(key2, units=uy, tex=tex)
@@ -518,15 +541,16 @@ def density_and_slice_plot(
     ax2 = ax.twinx()
     # ax2.set_ylim(0, 1e-6)
     x2 = slice_dat["mean_" + key1] / f1
-    ulist = [particle_group.units(k).unitSymbol for k in stat_keys]
+    ulist = [particle_group.units(k) for k in stat_keys]
 
     max2 = max([np.ptp(slice_dat[k]) for k in stat_keys])
 
-    f3, p3 = nice_scale_prefix(max2)
+    f3, _ = nice_scale_prefix(max2)
 
-    u2 = ulist[0]
-    assert all([u == u2 for u in ulist])
-    u2 = p3 + u2
+    u0 = ulist[0]
+    if not all(u == u0 for u in ulist):
+        raise ValueError(f"Incompatible units: {[u.unitSymbol for u in ulist]}")
+    u2 = u0.scaled_symbol(f3)
     labely2 = mathlabel(*stat_keys, units=u2, tex=tex)
     for k in stat_keys:
         label = mathlabel(k, units=u2, tex=tex)
@@ -799,7 +823,13 @@ def plot_fieldmesh_rectangular_1d(
 
     field_unit = fm.units(fieldmesh_component)
 
-    ylabel = r"$" + field_component[0] + "_" + field_component[1] + rf"$ ({field_unit})"
+    ylabel = (
+        r"$"
+        + field_component[0]
+        + "_"
+        + field_component[1]
+        + rf"~({field_unit.to_tex()})$"
+    )
     label = r"$" + field_component[0] + "_" + field_component[1] + "(x=y=0, z)$"
 
     z, field0 = fm.axis_values("z", field_component)
@@ -946,9 +976,9 @@ def plot_fieldmesh_rectangular_2d(
         field_2d = interpolated_values.reshape(len(x), len(y))
 
     if nice:
-        field_2d, _, prefix = nice_array(field_2d)
+        field_2d, field_f, _ = nice_array(field_2d)
     else:
-        prefix = ""
+        field_f = 1
 
     dmin = field_2d.min()
     dmax = field_2d.max()
@@ -961,11 +991,8 @@ def plot_fieldmesh_rectangular_2d(
     axes.set_ylabel(ylabel)
 
     # Add legend
-    llabel = (
-        r"$"
-        + f"{component[0]}_{component[1]}({plane})"
-        + rf"$ ({prefix}{unit.unitSymbol})"
-    )
+    units_str = unit.scaled_symbol(field_f)
+    llabel = r"$" + f"{component[0]}_{component[1]}({plane})" + rf"$ ({units_str})"
 
     if np.all(np.isclose(np.imag(field_2d), 0)):  # Close to real
         axes.imshow(
@@ -975,7 +1002,7 @@ def plot_fieldmesh_rectangular_2d(
         dmax = np.real(field_2d.max())
 
         if not fm.is_static:
-            llabel = "Re" + llabel + "]"
+            llabel = "Re[" + llabel + "]"
 
     elif np.all(np.isclose(np.real(field_2d), 0)):  # Close to imag
         axes.imshow(
@@ -985,7 +1012,7 @@ def plot_fieldmesh_rectangular_2d(
         dmax = np.imag(field_2d.max())
 
         if not fm.is_static:
-            llabel = "Im" + llabel
+            llabel = "Im[" + llabel + "]"
 
     else:
         raise ValueError("Complex components not supported")
@@ -1176,20 +1203,13 @@ def plot_1d_density(
     x_units_base = str(x_units) if x_units else None
     y_units_base = str(y_units) if y_units else None
 
-    # Form nice arrays
-    x, f1, p1, x_min, x_max = plottable_array(x, nice=nice, lim=xlim)
-    y, f2, p2, y_min, y_max = plottable_array(y, nice=nice, lim=ylim)
-
-    # Update units with prefixes
-    if x_units:
-        x_units = p1 + str(x_units)
-    else:
-        x_units = p1 if p1 else None
-
-    if y_units:
-        y_units = p2 + str(y_units)
-    else:
-        y_units = p2 if p2 else None
+    # Form nice arrays with display units (bare prefix when units unknown)
+    x, f1, x_units, x_min, x_max = plottable_array_and_units(
+        x, x_units, nice=nice, lim=xlim
+    )
+    y, f2, y_units, y_min, y_max = plottable_array_and_units(
+        y, y_units, nice=nice, lim=ylim
+    )
 
     # Compute bar widths from x spacing for continuous bars
     if len(x) > 1:
@@ -1253,7 +1273,7 @@ def plot_1d_density(
         # Note: cdf has units of y * widths (density * position)
         cdf = np.cumsum(y * widths) * f1 * f2
 
-        cdf_scaled, _, cdf_prefix, _, _ = plottable_array(cdf, nice=nice)
+        cdf_scaled, cdf_f, cdf_prefix, _, _ = plottable_array(cdf, nice=nice)
 
         # Default CDF style
         if cdf_style is None:
@@ -1265,10 +1285,11 @@ def plot_1d_density(
         # CDF has units of y_base * x_base with combined prefix
         if x_units_base and y_units_base:
             try:
-                cdf_units_base = (
-                    pmd_unit(y_units_base) * pmd_unit(x_units_base)
-                ).simplify()
-                cdf_units_str = cdf_prefix + str(cdf_units_base)
+                # Fold the display scale into the unit value before
+                # simplifying, so e.g. 1e-6 * (mA*s) labels as 'µC' rather
+                # than a double-prefixed 'µmC'.
+                cdf_units_base = pmd_unit(y_units_base) * pmd_unit(x_units_base)
+                cdf_units_str = cdf_units_base.simplify().scaled_symbol(cdf_f)
                 ax_cdf.set_ylabel(f"{cdf_label} ({cdf_units_str})")
             except (ValueError, KeyError, TypeError) as e:
                 # If unit parsing/multiplication fails, fall back to simpler label
@@ -1560,19 +1581,18 @@ def wakefield_plot(
         z = -c_light * np.asarray(particle_group.t)
     kicks = wake.particle_kicks(z=z, weight=particle_group.weight)
 
-    x, f1, p1, xmin, xmax = plottable_array(x_raw, nice=nice, lim=xlim)
-    y, f2, p2, ymin, ymax = plottable_array(kicks, nice=nice, lim=ylim)
+    x, f1, ux, xmin, xmax = plottable_array_and_units(
+        x_raw, particle_group.units(key), nice=nice, lim=xlim
+    )
+    y, f2, uy, ymin, ymax = plottable_array_and_units(
+        kicks, "eV/m", nice=nice, lim=ylim
+    )
 
     ax.scatter(x, y, marker=".", color="black", s=0.5)
 
     # Labels
-    ux = p1 + particle_group.units(key).unitSymbol
-    labelx = mathlabel(key, units=ux, tex=tex)
-    ax.set_xlabel(labelx)
-
-    uy = p2 + "eV/m"
-    labely = mathlabel("W_z", units=uy, tex=tex)
-    ax.set_ylabel(labely)
+    ax.set_xlabel(mathlabel(key, units=ux, tex=tex))
+    ax.set_ylabel(mathlabel("W_z", units=uy, tex=tex))
 
     # Limits
     if xlim:

--- a/beamphysics/readers.py
+++ b/beamphysics/readers.py
@@ -133,7 +133,7 @@ def is_constant_component(h5):
     """
     Constant record component should have 'value' and 'shape'
     """
-    return "value" and "shape" in h5.attrs
+    return "value" in h5.attrs and "shape" in h5.attrs
 
 
 def constant_component_value(h5):
@@ -323,8 +323,14 @@ def component_str(particle_group, name):
     record_name = name.split("/")[0]
     expected_dimension = expected_record_unit_dimension[record_name]
     this_dimension = component_unit_dimension(g)
-    dname = dimension_name(this_dimension)
-    symbol = SI_symbol[dname]
+    # A file may carry a dimension this package has no name for (e.g. from
+    # another openPMD extension); describe it rather than raising KeyError.
+    try:
+        dname = dimension_name(this_dimension)
+        symbol = SI_symbol[dname]
+    except KeyError:
+        dname = str(tuple(this_dimension))
+        symbol = "?"
 
     s = name + " "
 

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import math
 import re
+import unicodedata
 import warnings
 from typing import Optional, Sequence
 
@@ -32,6 +33,11 @@ Limit = tuple[Optional[float], Optional[float]]
 # fractional powers (e.g. from sqrt_unit) round-trip through the same code
 # path as integer ones. Equality with int tuples still works (``1.0 == 1``).
 Dimension = tuple[float, float, float, float, float, float, float]
+
+# Homoglyph folding applied to symbols on parse (after NFC normalization,
+# which already folds U+2126 OHM SIGN into U+03A9 GREEK CAPITAL OMEGA):
+# GREEK SMALL MU -> MICRO SIGN, the codepoint SHORT_PREFIX_FACTOR uses.
+_HOMOGLYPH_TRANSLATION = str.maketrans({"μ": "µ"})
 
 # Module-level dict that will be populated after NAMED_UNITS is created
 # This avoids the globals() check chicken-and-egg problem
@@ -190,7 +196,17 @@ class pmd_unit:
         # stripped. We do not split on whitespace (no implicit space-as-*),
         # which would conflict with multi-token named units like "charge #"
         # and with the SI-prefix fallback ("k eV" vs "keV").
-        unitSymbol = unitSymbol.strip()
+        #
+        # Unicode homoglyphs are folded to the codepoints used by the unit
+        # tables: NFC maps U+2126 OHM SIGN to U+03A9 GREEK CAPITAL OMEGA
+        # (the codepoint Unicode itself recommends, and the one NAMED_UNITS
+        # uses), and GREEK SMALL MU (U+03BC) is translated to MICRO SIGN
+        # (U+00B5), which is what SHORT_PREFIX_FACTOR keys on.
+        unitSymbol = (
+            unicodedata.normalize("NFC", unitSymbol)
+            .translate(_HOMOGLYPH_TRANSLATION)
+            .strip()
+        )
 
         # Check if known_unit dict has been populated
         if not known_unit:
@@ -877,7 +893,19 @@ def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     if s1 == s2:
         symbol = "1"
     else:
-        symbol = s1 + "/" + s2
+        # The parser is flat and left-associative ("a/b/c" means (a/b)/c), so
+        # writing f"{s1}/{s2}" with a *compound* divisor would regroup:
+        # V/(eV/c) emitted as "V/eV/c" reads back as V/(eV*c). Distribute the
+        # division across the divisor's tokens instead, inverting each of its
+        # operators: a/(b*c) -> a/b/c and a/(b/c) -> a/b*c. A compound
+        # numerator needs no such care — appended operators apply to the whole
+        # accumulated value under left association. An empty numerator symbol
+        # (the dimensionless identity) is emitted as "1" so the result does
+        # not start with a bare operator.
+        numerator = s1 if s1 else "1"
+        parts, ops = _tokenize_compound(s2)
+        inverted = ["/"] + ["*" if op == "/" else "/" for op in ops]
+        symbol = numerator + "".join(op + p for op, p in zip(inverted, parts))
     d1 = u1.unitDimension
     d2 = u2.unitDimension
     dim = tuple(a - b for a, b in zip(d1, d2))

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -360,6 +360,81 @@ class pmd_unit:
     def __truediv__(self, other) -> pmd_unit:
         return divide_units(self, other)
 
+    def __pow__(self, power: float) -> pmd_unit:
+        return power_unit(self, power)
+
+    def compatible_with(self, other: pmd_unit) -> bool:
+        """Return ``True`` when ``other`` has the same dimension as ``self``.
+
+        Compatibility is a pure-dimension check: two units are compatible
+        iff a value expressed in one can be converted to the other by a
+        single multiplicative SI factor (see :meth:`conversion_factor_to`).
+        It does *not* require equal :attr:`unitSI`, so e.g. ``eV`` and
+        ``J`` are compatible.
+
+        Parameters
+        ----------
+        other : pmd_unit
+            The unit to compare against.
+
+        Returns
+        -------
+        bool
+            ``True`` iff ``self.unitDimension == other.unitDimension``.
+
+        Examples
+        --------
+        >>> pmd_unit("eV").compatible_with(pmd_unit("J"))
+        True
+        >>> pmd_unit("Hz").compatible_with(pmd_unit("1/s"))
+        True
+        >>> pmd_unit("m").compatible_with(pmd_unit("s"))
+        False
+        """
+        if not isinstance(other, pmd_unit):
+            raise TypeError(
+                f"compatible_with expects a pmd_unit, got {type(other).__name__}"
+            )
+        return self.unitDimension == other.unitDimension
+
+    def conversion_factor_to(self, other: pmd_unit) -> float:
+        """Return the factor that converts a value in ``self`` to ``other``.
+
+        For a value ``x`` measured in ``self``, the value in ``other`` is
+        ``x * self.conversion_factor_to(other)``. Equivalent to
+        ``self.unitSI / other.unitSI`` after a dimension check.
+
+        Parameters
+        ----------
+        other : pmd_unit
+            The target unit. Must have the same :attr:`unitDimension` as
+            ``self``.
+
+        Returns
+        -------
+        float
+            Multiplicative factor mapping values in ``self`` to ``other``.
+
+        Raises
+        ------
+        ValueError
+            If ``other`` is not dimensionally :meth:`compatible_with` ``self``.
+
+        Examples
+        --------
+        >>> pmd_unit("eV").conversion_factor_to(pmd_unit("J"))
+        1.602176634e-19
+        >>> pmd_unit("km").conversion_factor_to(pmd_unit("m"))
+        1000.0
+        """
+        if not self.compatible_with(other):
+            raise ValueError(
+                f"Incompatible units: {self.unitSymbol!r} (dimension "
+                f"{self.unitDimension}) cannot be converted to "
+                f"{other.unitSymbol!r} (dimension {other.unitDimension})."
+            )
+        return self.unitSI / other.unitSI
+
     def __eq__(self, other) -> bool:
         # Per the openPMD standard, a unit is defined by (unitSI,
         # unitDimension); the symbol is a presentational hint. Two units are
@@ -1263,7 +1338,7 @@ for k in ["power"]:
 for k in ["norm_emit_x", "norm_emit_y"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("m")
 for k in ["norm_emit_4d"]:
-    PARTICLEGROUP_UNITS[k] = pmd_unit("m") * pmd_unit("m")
+    PARTICLEGROUP_UNITS[k] = pmd_unit("m") ** 2
 for k in ["Lz"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("m") * pmd_unit("eV/c")
 for k in ["xp", "yp"]:
@@ -1422,13 +1497,16 @@ def read_dataset_and_unit_h5(h5, expected_unit=None, convert=True):
         # Try to get unit
         expected_unit = pmd_unit(expected_unit)
 
-    # Check dimensions
-    du = u / expected_unit
-
-    assert du.unitDimension == (0, 0, 0, 0, 0, 0, 0), "incompatible units"
+    if not u.compatible_with(expected_unit):
+        raise ValueError(
+            f"Incompatible units: file unit {u.unitSymbol!r} (dimension "
+            f"{u.unitDimension}) does not match expected "
+            f"{expected_unit.unitSymbol!r} (dimension "
+            f"{expected_unit.unitDimension})."
+        )
 
     if convert:
-        fac = du.unitSI
+        fac = u.conversion_factor_to(expected_unit)
         return fac * np.array(h5), expected_unit
     else:
         return np.array(h5), u

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -168,6 +168,13 @@ class pmd_unit:
         ValueError
             If the symbol is not found in known_unit dict or cannot be parsed.
         """
+        # Strip outer whitespace so users can write "  eV/c" or "kg*m / s".
+        # Per-token whitespace inside the operator-split branch below is also
+        # stripped. We do not split on whitespace (no implicit space-as-*),
+        # which would conflict with multi-token named units like "charge #"
+        # and with the SI-prefix fallback ("k eV" vs "keV").
+        unitSymbol = unitSymbol.strip()
+
         # Check if known_unit dict has been populated
         if not known_unit:
             raise ValueError(
@@ -219,6 +226,7 @@ class pmd_unit:
                     current += char
 
             parts.append(current)  # Don't forget the last part
+            parts = [p.strip() for p in parts]
 
             # Parse the first part (may include ^power)
             result = cls._parse_single_unit(parts[0])
@@ -576,10 +584,12 @@ def multiply_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
 
     s1 = u1.unitSymbol
     s2 = u2.unitSymbol
-    if s1 == s2:
-        symbol = f"({s1})^2"
-    else:
-        symbol = s1 + "*" + s2
+    # No special case for s1 == s2: writing "s1^2" would be wrong when s1 is
+    # itself compound (e.g. "kg*m^2" parses as kg*(m^2), not (kg*m)^2), and
+    # wrapping in parens ("(s1)^2") produces a symbol the parser cannot read
+    # back. The plain "s1*s2" form always round-trips and yields the correct
+    # dimension regardless of whether either operand is atomic or compound.
+    symbol = s1 + "*" + s2
     d1 = u1.unitDimension
     d2 = u2.unitDimension
     dim = tuple(sum(x) for x in zip(d1, d2))
@@ -721,9 +731,11 @@ def make_dimension(dim: Sequence[int | float]) -> Dimension:
     The openPMD standard defines ``unitDimension`` as an array of 7
     ``float64`` values, so floats are used uniformly here. This also lets
     fractional exponents (e.g. from :func:`sqrt_unit`) share a single
-    representation with integer ones.
+    representation with integer ones. Negative zeros (from e.g. ``-1.0 * 0.0``
+    inside :func:`power_unit`) are normalized to positive ``0.0`` so the
+    ``repr`` is stable and exponent tuples compare cleanly as dict keys.
     """
-    dim = tuple(float(d) for d in dim)
+    dim = tuple(0.0 if d == 0 else float(d) for d in dim)
     if len(dim) != 7:
         raise ValueError("Dimensions must be 7 elements.")
     return dim
@@ -787,6 +799,11 @@ NAMED_UNITS = [
     pmd_unit("eV", e_charge, "energy"),
     pmd_unit("J", 1, "energy"),
     pmd_unit("eV/c", e_charge / c_light, "momentum"),
+    # The Newton as the force (dimension L M T^-2) is intentionally represented as eV/m and J/m
+    # rather than N: the accelerator-physics convention writes accelerating
+    # gradients as eV/m or MV/m, and adding "N" here would beat them in
+    # _symbol_complexity (shorter symbol wins) and change existing simplify()
+    # output.
     pmd_unit("eV/m", e_charge, (1, 1, -2, 0, 0, 0, 0)),
     pmd_unit("J/m", 1, (1, 1, -2, 0, 0, 0, 0)),
     pmd_unit("W", 1, (2, 1, -3, 0, 0, 0, 0)),

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -112,11 +112,17 @@ class pmd_unit:
     >>> pmd_unit.from_symbol('A*s')
     pmd_unit('A*s', 1, (0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0))
 
-    Simple equalities are possible:
+    Equality follows the openPMD standard: the symbol is presentational and
+    two units are equal when they share the same ``unitDimension`` and
+    ``unitSI`` (compared with a small relative tolerance):
 
     >>> pmd_unit("T") == pmd_unit("T")
     True
     >>> pmd_unit("eV") == pmd_unit("T")
+    False
+    >>> pmd_unit("1/s") == pmd_unit("Hz")
+    True
+    >>> pmd_unit("J/m") == pmd_unit("eV/m")  # different SI scales, unequal
     False
     """
 
@@ -126,6 +132,17 @@ class pmd_unit:
         unitSI: int | float = 0,
         unitDimension: str | Sequence[int | float] = (0, 0, 0, 0, 0, 0, 0),
     ):
+        # The openPMD standard defines unitSI as a positive conversion factor
+        # to the corresponding SI unit. Negative scales would invert the sign
+        # of every value an instrument writes through this unit, so they are
+        # rejected here. (unitSI=0 is permitted as the sentinel that triggers
+        # symbol lookup below.)
+        if unitSI < 0:
+            raise ValueError(
+                f"unitSI must be non-negative (got {unitSI!r}). "
+                "The openPMD standard defines unitSI as a conversion factor to SI."
+            )
+
         # Use the provided values directly when unitSI is given explicitly, or
         # while NAMED_UNITS is still being built (known_unit not yet populated).
         # Otherwise look the symbol up / parse it.
@@ -192,41 +209,29 @@ class pmd_unit:
             result._unitSymbol = unitSymbol
             return result
 
-        # Handle sqrt() notation: sqrt(X) = X^0.5
-        sqrt_match = re.match(r"^sqrt\((.+)\)$", unitSymbol)
+        # Handle sqrt() notation: sqrt(X) = X^0.5. The stored symbol is
+        # always the canonical, whitespace-free "sqrt(<inner>)" form so that
+        # "sqrt( m )", "sqrt(m)", and "  sqrt(m)" all compare equal and hash
+        # identically.
+        sqrt_match = re.match(r"^sqrt\(\s*(.+?)\s*\)$", unitSymbol)
         if sqrt_match:
             inner = sqrt_match.group(1)
             base_unit = cls.from_symbol(inner)
             result = power_unit(base_unit, 0.5)
-            # Preserve the original sqrt notation in the symbol
-            result._unitSymbol = unitSymbol
+            result._unitSymbol = f"sqrt({base_unit.unitSymbol})"
             return result
 
         # Not in known_unit - try operator parsing (e.g., "A*s", "kg*m/s", "m^2")
         if "*" in unitSymbol or "/" in unitSymbol or "^" in unitSymbol:
-            # Tokenize: split by * and / but not inside parentheses
-            # This allows m^(-3/2) to remain intact
-            parts = []
-            operators = []
-            current = ""
-            paren_depth = 0
+            parts, operators = _tokenize_compound(unitSymbol)
 
-            for char in unitSymbol:
-                if char == "(":
-                    paren_depth += 1
-                    current += char
-                elif char == ")":
-                    paren_depth -= 1
-                    current += char
-                elif char in "*/" and paren_depth == 0:
-                    parts.append(current)
-                    operators.append(char)
-                    current = ""
-                else:
-                    current += char
-
-            parts.append(current)  # Don't forget the last part
-            parts = [p.strip() for p in parts]
+            # Reject malformed compound input (empty operand around an
+            # operator). Previously these silently parsed because the empty
+            # token resolved to the identity (""): "m*" -> m*1 = m, "/m" -> 1/m.
+            if any(p == "" for p in parts):
+                raise ValueError(
+                    f"Malformed unit symbol {unitSymbol!r}: empty operand around an operator."
+                )
 
             # Parse the first part (may include ^power)
             result = cls._parse_single_unit(parts[0])
@@ -239,8 +244,10 @@ class pmd_unit:
                 elif op == "/":
                     result = result / unit_obj
 
-            # Preserve the original symbol but keep computed dimension
-            result._unitSymbol = unitSymbol
+            # Canonical symbol: stripped tokens joined by the original
+            # operators with no whitespace. So "eV / c" and "eV/c" share a
+            # symbol (and therefore compare equal / hash identically).
+            result._unitSymbol = _join_compound(parts, operators)
             return result
 
         # Single token, not directly known: delegate to _parse_single_unit,
@@ -264,6 +271,10 @@ class pmd_unit:
         pmd_unit
             The parsed unit object.
         """
+        # Strip whitespace around the token and around any "^" so callers can
+        # write "m ^ 2" or "  m^2" interchangeably with "m^2".
+        part = re.sub(r"\s*\^\s*", "^", part.strip())
+
         # Check if it's a known unit first. Return a shallow copy, never the
         # shared cached object: callers (e.g. from_symbol) reassign
         # ``_unitSymbol`` on the result, which would otherwise mutate the
@@ -273,13 +284,14 @@ class pmd_unit:
             result._unitSymbol = part
             return result
 
-        # Check for sqrt() notation
-        sqrt_match = re.match(r"^sqrt\((.+)\)$", part)
+        # Check for sqrt() notation. Whitespace inside the parens is stripped
+        # and the stored symbol is canonicalized to "sqrt(<inner>)".
+        sqrt_match = re.match(r"^sqrt\(\s*(.+?)\s*\)$", part)
         if sqrt_match:
             inner = sqrt_match.group(1)
             base_unit = cls._parse_single_unit(inner)
             result = power_unit(base_unit, 0.5)
-            result._unitSymbol = part
+            result._unitSymbol = f"sqrt({base_unit.unitSymbol})"
             return result
 
         # Check for power notation with parenthesized fraction: m^(-3/2)
@@ -323,7 +335,12 @@ class pmd_unit:
         raise ValueError(f"Unknown unitSymbol: {part}")
 
     def __hash__(self) -> int:
-        return hash((self.unitSymbol, self.unitSI, self.unitDimension))
+        # The openPMD standard defines a unit by (unitSI, unitDimension); the
+        # symbol is presentational. Hash on unitDimension alone so that any
+        # two equal units (per __eq__'s isclose comparison on unitSI) share a
+        # hash bucket — preserving the hash/eq invariant even when unitSI
+        # values arrived via slightly different arithmetic paths.
+        return hash(self.unitDimension)
 
     @property
     def unitSymbol(self) -> str:
@@ -344,9 +361,19 @@ class pmd_unit:
         return divide_units(self, other)
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
+        # Per the openPMD standard, a unit is defined by (unitSI,
+        # unitDimension); the symbol is a presentational hint. Two units are
+        # equal when both fields match, with math.isclose on unitSI to
+        # absorb floating-point drift from arithmetic like
+        # (eV/c) * c -> eV (the eV value reconstructed through c_light
+        # round-tripping may differ from e_charge by 1 ULP).
+        if not isinstance(other, self.__class__):
+            return False
+        if self.unitDimension != other.unitDimension:
+            return False
+        return math.isclose(
+            self.unitSI, other.unitSI, rel_tol=_SIMPLIFY_REL_TOL, abs_tol=0.0
+        )
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
@@ -406,6 +433,81 @@ class pmd_unit:
 
         return self
 
+    def to_tex(self) -> str:
+        """Render the stored unit symbol as a matplotlib-mathtext string.
+
+        The translation is purely structural — no algebraic simplification
+        or reordering. Each atomic unit name is wrapped in ``\\mathrm{...}``
+        (so it renders upright), ``*`` becomes ``{\\cdot}``, ``/`` is kept
+        as ``/``, ``^N`` becomes ``^{N}``, and ``sqrt(X)`` becomes
+        ``\\sqrt{...}`` (recursing on the inner expression).
+
+        The result is intended to be embedded inside an ``$...$`` mathtext
+        block by the caller. The identity / empty symbol returns ``""``.
+
+        Returns
+        -------
+        str
+            A TeX fragment equivalent to :attr:`unitSymbol`.
+
+        Examples
+        --------
+        >>> pmd_unit("eV/c").to_tex()
+        '\\\\mathrm{eV}/\\\\mathrm{c}'
+
+        >>> pmd_unit("kg*m/s").to_tex()
+        '\\\\mathrm{kg}{\\\\cdot}\\\\mathrm{m}/\\\\mathrm{s}'
+
+        >>> pmd_unit("m^2").to_tex()
+        '\\\\mathrm{m}^{2}'
+
+        >>> pmd_unit("sqrt(m)").to_tex()
+        '\\\\sqrt{\\\\mathrm{m}}'
+        """
+        return _symbol_to_tex(self._unitSymbol)
+
+
+def _symbol_to_tex(symbol: str) -> str:
+    """Recursive worker for :meth:`pmd_unit.to_tex`."""
+    if symbol == "":
+        return ""
+    if symbol == "1":
+        return "1"
+
+    # Top-level compound (``a*b``, ``a/b``, ``sqrt(a)*b``). Tokenize first so
+    # the recursion handles nested ``sqrt(...)`` and per-token powers.
+    if "*" in symbol or "/" in symbol:
+        parts, operators = _tokenize_compound(symbol)
+        if len(parts) > 1:
+            tex_parts = [_symbol_to_tex(p) for p in parts]
+            out = tex_parts[0]
+            for op, p in zip(operators, tex_parts[1:]):
+                out += r"{\cdot}" + p if op == "*" else "/" + p
+            return out
+
+    # sqrt(X) -> \sqrt{ <recursed X> }
+    sqrt_match = re.match(r"^sqrt\((.+)\)$", symbol)
+    if sqrt_match:
+        inner = _symbol_to_tex(sqrt_match.group(1))
+        return rf"\sqrt{{{inner}}}"
+
+    # base^(n/d) -> \mathrm{base}^{n/d}
+    paren_power_match = _TOKEN_PAREN_POWER_RE.match(symbol)
+    if paren_power_match:
+        base = _symbol_to_tex(paren_power_match.group(1))
+        num = paren_power_match.group(2)
+        den = paren_power_match.group(3)
+        return rf"{base}^{{{num}/{den}}}"
+
+    # base^N -> \mathrm{base}^{N}
+    power_match = _TOKEN_POWER_RE.match(symbol)
+    if power_match:
+        base = _symbol_to_tex(power_match.group(1))
+        return f"{base}^{{{power_match.group(2)}}}"
+
+    # Atomic name (possibly with internal whitespace, e.g. "charge #").
+    return rf"\mathrm{{{symbol}}}"
+
 
 def is_dimensionless(u: pmd_unit) -> bool:
     """Checks if the unit is dimensionless"""
@@ -423,6 +525,49 @@ def is_identity(u: pmd_unit) -> bool:
 
 _SIMPLIFY_REL_TOL = 1e-9
 _DIMENSIONLESS: Dimension = (0, 0, 0, 0, 0, 0, 0)
+
+
+def _tokenize_compound(symbol: str) -> tuple[list[str], list[str]]:
+    """Split ``symbol`` on top-level ``*`` and ``/`` (respecting parentheses).
+
+    Returns ``(parts, operators)`` where each part is whitespace-stripped and
+    ``operators[i]`` joins ``parts[i]`` to ``parts[i+1]``. Used by both the
+    parser and :func:`power_unit` (for distributing an exponent across a
+    compound symbol).
+    """
+    parts: list[str] = []
+    operators: list[str] = []
+    current = ""
+    paren_depth = 0
+    for char in symbol:
+        if char == "(":
+            paren_depth += 1
+            current += char
+        elif char == ")":
+            paren_depth -= 1
+            current += char
+        elif char in "*/" and paren_depth == 0:
+            parts.append(current)
+            operators.append(char)
+            current = ""
+        else:
+            current += char
+    parts.append(current)
+    return [p.strip() for p in parts], operators
+
+
+def _join_compound(parts: Sequence[str], operators: Sequence[str]) -> str:
+    """Inverse of :func:`_tokenize_compound`: re-emit a flat compound symbol."""
+    out = parts[0]
+    for op, p in zip(operators, parts[1:]):
+        out += op + p
+    return out
+
+
+def _is_atomic_symbol(symbol: str) -> bool:
+    """True if the symbol has no top-level ``*`` or ``/`` (parens are kept)."""
+    parts, _ = _tokenize_compound(symbol)
+    return len(parts) == 1
 
 
 def _symbol_complexity(symbol: str) -> tuple[int, int, str]:
@@ -495,15 +640,16 @@ def _best_compound_match(
 ) -> pmd_unit | None:
     """
     Find the simplest ``a*b`` or ``a/b`` of two named units that matches
-    the target dimension and SI value exactly. Dimensionless factors are
-    skipped to avoid trivial decorations like ``"m*1"``.
+    the target dimension and SI value exactly. Both ``a`` and ``b`` must be
+    atomic (no ``*`` or ``/`` in the symbol):
 
-    The symbol parser is flat and left-associative (``a/b/c`` means
-    ``(a/b)/c``), so a divisor that itself contains ``*`` or ``/`` would be
-    regrouped when the symbol is re-parsed (``a/(b/c)`` written as
-    ``"a/b/c"`` reads back as ``a/(b*c)``). The ``a/b`` form therefore only
-    accepts an operator-free divisor; the ``a*b`` form is unaffected because
-    a product chain is associative under the parser's grouping.
+    * A compound divisor would be regrouped under the parser's flat,
+      left-associative grouping (``a/(b/c)`` written as ``"a/b/c"`` reads
+      back as ``a/(b*c)``).
+    * A compound numerator parses correctly but reads as something else to
+      a human (``"J/m*s"`` left-associates to ``(J/m)*s`` -- correct, but
+      looks like ``J/(m*s)``). Restricting to atomic operands keeps the
+      emitted symbol unambiguous to readers.
 
     A dimensionless target is never matched: it is a pure number, and any
     ``a*b`` / ``a/b`` reaching it would pair two same-dimension units (e.g.
@@ -515,6 +661,8 @@ def _best_compound_match(
     dim_index: dict[Dimension, list[pmd_unit]] = {}
     for u in named_units:
         if u.unitDimension == _DIMENSIONLESS or u.unitSI == 0:
+            continue
+        if not _is_atomic_symbol(u.unitSymbol):
             continue
         dim_index.setdefault(u.unitDimension, []).append(u)
 
@@ -543,9 +691,6 @@ def _best_compound_match(
         div_dim = tuple(ad - td for ad, td in zip(a.unitDimension, target_dim))
         div_target_si = a_si / target_si
         for b in dim_index.get(div_dim, ()):
-            # An operator-containing divisor would be regrouped on re-parse.
-            if any(op in b.unitSymbol for op in "*/"):
-                continue
             if not math.isclose(b.unitSI, div_target_si, rel_tol=_SIMPLIFY_REL_TOL):
                 continue
             sym = f"{a.unitSymbol}/{b.unitSymbol}"
@@ -639,6 +784,9 @@ def sqrt_unit(u: pmd_unit) -> pmd_unit:
     """
     Returns the square root of a unit.
 
+    The emitted symbol uses the canonical ``sqrt(<inner>)`` form (no
+    whitespace, no LaTeX wrapping) so it round-trips through the parser.
+
     Parameters
     ----------
     u : pmd_unit
@@ -654,7 +802,7 @@ def sqrt_unit(u: pmd_unit) -> pmd_unit:
     result = power_unit(u, 0.5)
     symbol = u.unitSymbol
     if symbol not in ["", "1"]:
-        result._unitSymbol = rf"\sqrt{{ {symbol} }}"
+        result._unitSymbol = f"sqrt({symbol})"
     return result
 
 
@@ -688,15 +836,62 @@ def power_unit(u: pmd_unit, power: float) -> pmd_unit:
     symbol = u.unitSymbol
     if symbol in ["", "1"]:
         new_symbol = symbol
-    elif power == int(power):
-        new_symbol = f"{symbol}^{int(power)}"
+    elif "*" in symbol or "/" in symbol:
+        # Distribute the exponent across a compound symbol. Naively writing
+        # "compound^n" is wrong: the parser is flat and left-associative, so
+        # "eV*s^2" parses as eV*(s^2), not (eV*s)^2. Instead, multiply each
+        # token's own exponent by ``power`` and re-emit.
+        new_symbol = _distribute_power_in_symbol(symbol, power)
     else:
-        new_symbol = f"{symbol}^{power}"
+        new_symbol = _format_power(symbol, power)
 
     unitSI = u.unitSI**power
     dim = tuple(d * power for d in u.unitDimension)
 
     return pmd_unit(new_symbol, unitSI=unitSI, unitDimension=dim)
+
+
+_TOKEN_PAREN_POWER_RE = re.compile(r"^(.+)\^\((-?\d+)/(\d+)\)$")
+_TOKEN_POWER_RE = re.compile(r"^(.+)\^(-?\d+(?:\.\d+)?)$")
+
+
+def _format_power(base: str, power: float) -> str:
+    """Render ``base^power`` with an integer exponent where possible."""
+    if power == 1:
+        return base
+    if power == int(power):
+        return f"{base}^{int(power)}"
+    return f"{base}^{power}"
+
+
+def _combine_token_power(token: str, factor: float) -> str:
+    """Multiply a token's existing exponent by ``factor``.
+
+    ``m`` with factor 2 becomes ``m^2``; ``s^2`` with factor 2 becomes
+    ``s^4``; ``m^(1/2)`` with factor 2 becomes ``m^1`` (i.e. ``m``).
+    Unknown / nested forms (e.g. ``sqrt(m)``) are wrapped as
+    ``sqrt(m)^factor`` and resolved by the parser's recursion.
+    """
+    paren_match = _TOKEN_PAREN_POWER_RE.match(token)
+    if paren_match:
+        base = paren_match.group(1)
+        existing = int(paren_match.group(2)) / int(paren_match.group(3))
+    else:
+        power_match = _TOKEN_POWER_RE.match(token)
+        if power_match:
+            base = power_match.group(1)
+            existing = float(power_match.group(2))
+        else:
+            base = token
+            existing = 1.0
+    return _format_power(base, existing * factor)
+
+
+def _distribute_power_in_symbol(symbol: str, power: float) -> str:
+    """Distribute an exponent across a compound symbol (e.g. ``(eV*s)^2``)."""
+    parts, operators = _tokenize_compound(symbol)
+    new_parts = [_combine_token_power(p, power) for p in parts]
+    return _join_compound(new_parts, operators)
 
 
 # length mass time current temperature mol luminous
@@ -799,11 +994,15 @@ NAMED_UNITS = [
     pmd_unit("eV", e_charge, "energy"),
     pmd_unit("J", 1, "energy"),
     pmd_unit("eV/c", e_charge / c_light, "momentum"),
-    # The Newton as the force (dimension L M T^-2) is intentionally represented as eV/m and J/m
-    # rather than N: the accelerator-physics convention writes accelerating
-    # gradients as eV/m or MV/m, and adding "N" here would beat them in
-    # _symbol_complexity (shorter symbol wins) and change existing simplify()
-    # output.
+    # The Newton (dimension L M T^-2, unitSI=1) is intentionally omitted.
+    # It does *not* conflict with eV/m / MeV/m (those have unitSI = n *
+    # e_charge, which is not within rel_tol=1e-9 of any SI-prefix factor
+    # times N=1, so the atomic-match prefix fallback never reaches N). It
+    # *does* however generate an "N/A" compound for the magnetic-rigidity
+    # dimension (T*m), which would beat the conventional "T*m" output of
+    # simplify() under the lexicographic tiebreaker. Until we have a way
+    # to prefer accelerator-physics-familiar spellings in the compound
+    # matcher, we leave SI-magnitude forces as "J/m".
     pmd_unit("eV/m", e_charge, (1, 1, -2, 0, 0, 0, 0)),
     pmd_unit("J/m", 1, (1, 1, -2, 0, 0, 0, 0)),
     pmd_unit("W", 1, (2, 1, -3, 0, 0, 0, 0)),

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -1064,7 +1064,6 @@ NAMED_UNITS = [
     pmd_unit("V/m", 1, "electric_field"),
     pmd_unit("V", 1, "electric_potential"),
     pmd_unit("c", c_light, "velocity"),  # Speed of light
-    pmd_unit("vel/c", c_light, "velocity"),
     pmd_unit("m/s", 1, "velocity"),
     pmd_unit("eV", e_charge, "energy"),
     pmd_unit("J", 1, "energy"),
@@ -1095,7 +1094,7 @@ known_unit.update(
     {
         "1": pmd_unit("", 1, "1"),
         "charge_num": pmd_unit("charge #", 1, "charge"),
-        "c_light": pmd_unit("vel/c", c_light, "velocity"),
+        "c_light": known_unit["c"],
         "deg": known_unit["degree"],
         "Ohm": known_unit["Ω"],  # ASCII alias for the ohm
     }

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -7,6 +7,7 @@ For more advanced units, use a package like Pint:
 
 from __future__ import annotations
 
+import copy
 import math
 import re
 import warnings
@@ -176,9 +177,13 @@ class pmd_unit:
 
         # known_unit exists - check if it's already a known unit (priority)
         if unitSymbol in known_unit:
-            # Copy internals from known unit
-            u = known_unit[unitSymbol]
-            return cls(unitSymbol, unitSI=u.unitSI, unitDimension=u.unitDimension)
+            # Shallow copy preserves the cached dimension/SI without
+            # re-coercing through make_dimension, while still letting callers
+            # reassign _unitSymbol without mutating the shared NAMED_UNITS
+            # entry. (All three slots are immutable: str, float, tuple.)
+            result = copy.copy(known_unit[unitSymbol])
+            result._unitSymbol = unitSymbol
+            return result
 
         # Handle sqrt() notation: sqrt(X) = X^0.5
         sqrt_match = re.match(r"^sqrt\((.+)\)$", unitSymbol)
@@ -251,12 +256,14 @@ class pmd_unit:
         pmd_unit
             The parsed unit object.
         """
-        # Check if it's a known unit first. Return a copy, never the shared
-        # cached object: callers (e.g. from_symbol) reassign ``_unitSymbol`` on
-        # the result, which would otherwise mutate the global NAMED_UNITS entry.
+        # Check if it's a known unit first. Return a shallow copy, never the
+        # shared cached object: callers (e.g. from_symbol) reassign
+        # ``_unitSymbol`` on the result, which would otherwise mutate the
+        # global NAMED_UNITS entry.
         if part in known_unit:
-            u = known_unit[part]
-            return cls(part, unitSI=u.unitSI, unitDimension=u.unitDimension)
+            result = copy.copy(known_unit[part])
+            result._unitSymbol = part
+            return result
 
         # Check for sqrt() notation
         sqrt_match = re.match(r"^sqrt\((.+)\)$", part)

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -113,6 +113,12 @@ class pmd_unit:
     >>> pmd_unit('kg*m/s')
     pmd_unit('kg*m/s', 1, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
 
+    Parsing is left-associative ('V/eV/c' means '(V/eV)/c'); parentheses
+    group a sub-expression into a single operand:
+
+    >>> pmd_unit('V/(eV/c)')
+    pmd_unit('V/(eV/c)', 1.8711573470618972e+27, (1.0, 0.0, -2.0, -1.0, 0.0, 0.0, 0.0))
+
     Alternatively, use the `from_symbol` class method for explicit symbol lookup:
 
     >>> pmd_unit.from_symbol('A*s')
@@ -241,20 +247,18 @@ class pmd_unit:
         if "*" in unitSymbol or "/" in unitSymbol or "^" in unitSymbol:
             parts, operators = _tokenize_compound(unitSymbol)
 
-            # Reject malformed compound input (empty operand around an
-            # operator). Previously these silently parsed because the empty
-            # token resolved to the identity (""): "m*" -> m*1 = m, "/m" -> 1/m.
+            # Reject empty operands around an operator ("m*", "/m", "m**s").
             if any(p == "" for p in parts):
                 raise ValueError(
                     f"Malformed unit symbol {unitSymbol!r}: empty operand around an operator."
                 )
 
-            # Parse the first part (may include ^power)
-            result = cls._parse_single_unit(parts[0])
-
-            # Process remaining parts
-            for op, part in zip(operators, parts[1:]):
-                unit_obj = cls._parse_single_unit(part)
+            # Parse every token, then combine. A parenthesized token like
+            # "(eV/c)" recursively parses its inner expression as a unit of
+            # its own.
+            token_units = [cls._parse_single_unit(p) for p in parts]
+            result = token_units[0]
+            for op, unit_obj in zip(operators, token_units[1:]):
                 if op == "*":
                     result = result * unit_obj
                 elif op == "/":
@@ -262,8 +266,18 @@ class pmd_unit:
 
             # Canonical symbol: stripped tokens joined by the original
             # operators with no whitespace. So "eV / c" and "eV/c" share a
-            # symbol (and therefore compare equal / hash identically).
-            result._unitSymbol = _join_compound(parts, operators)
+            # symbol (and therefore compare equal / hash identically). A
+            # parenthesized token is re-emitted from its parsed unit, so
+            # "( eV / c )" canonicalizes to "(eV/c)" — and the parens are
+            # dropped entirely when the group is atomic ("(m)" -> "m").
+            canonical_parts = []
+            for p, u in zip(parts, token_units):
+                if p.startswith("(") and p.endswith(")") and _parens_balanced(p[1:-1]):
+                    s = u.unitSymbol
+                    canonical_parts.append(s if _is_atomic_symbol(s) else f"({s})")
+                else:
+                    canonical_parts.append(p)
+            result._unitSymbol = _join_compound(canonical_parts, operators)
             return result
 
         # Single token, not directly known: delegate to _parse_single_unit,
@@ -309,6 +323,16 @@ class pmd_unit:
             result = power_unit(base_unit, 0.5)
             result._unitSymbol = f"sqrt({base_unit.unitSymbol})"
             return result
+
+        # Parenthesized grouping: "(eV/c)" parses the inner expression as a
+        # unit of its own, so "V/(eV/c)" divides by the whole group and
+        # "(eV*s)^2" exponentiates it (via the power branches below, whose
+        # base recursion lands back here). The balanced-parens guard keeps
+        # adjacent groups with no operator, like "(a)(b)", from matching as
+        # one group with inner "a)(b".
+        paren_group_match = re.match(r"^\((.+)\)$", part)
+        if paren_group_match and _parens_balanced(paren_group_match.group(1)):
+            return cls.from_symbol(paren_group_match.group(1))
 
         # Check for power notation with parenthesized fraction: m^(-3/2)
         paren_power_match = re.match(r"^(.+)\^\((-?\d+)/(\d+)\)$", part)
@@ -530,8 +554,9 @@ class pmd_unit:
         The translation is purely structural — no algebraic simplification
         or reordering. Each atomic unit name is wrapped in ``\\mathrm{...}``
         (so it renders upright), ``*`` becomes ``{\\cdot}``, ``/`` is kept
-        as ``/``, ``^N`` becomes ``^{N}``, and ``sqrt(X)`` becomes
-        ``\\sqrt{...}`` (recursing on the inner expression).
+        as ``/``, ``^N`` becomes ``^{N}``, ``sqrt(X)`` becomes
+        ``\\sqrt{...}``, and a parenthesized group ``(X)`` keeps its parens
+        (recursing on the inner expression in both cases).
 
         The result is intended to be embedded inside an ``$...$`` mathtext
         block by the caller. The identity / empty symbol returns ``""``.
@@ -581,6 +606,13 @@ def _symbol_to_tex(symbol: str) -> str:
     if sqrt_match:
         inner = _symbol_to_tex(sqrt_match.group(1))
         return rf"\sqrt{{{inner}}}"
+
+    # Parenthesized group: "(X)" -> ( <recursed X> ). The balanced guard
+    # mirrors the parser's, so "(a)(b)" falls through to the atomic fallback
+    # rather than matching as one group.
+    paren_group_match = re.match(r"^\((.+)\)$", symbol)
+    if paren_group_match and _parens_balanced(paren_group_match.group(1)):
+        return "(" + _symbol_to_tex(paren_group_match.group(1)) + ")"
 
     # base^(n/d) -> \mathrm{base}^{n/d}
     paren_power_match = _TOKEN_PAREN_POWER_RE.match(symbol)
@@ -678,8 +710,21 @@ def _tokenize_compound(symbol: str) -> tuple[list[str], list[str]]:
     return [p.strip() for p in parts], operators
 
 
+def _parens_balanced(symbol: str) -> bool:
+    """True if parentheses in ``symbol`` are balanced and never close early."""
+    depth = 0
+    for char in symbol:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
+
+
 def _join_compound(parts: Sequence[str], operators: Sequence[str]) -> str:
-    """Inverse of :func:`_tokenize_compound`: re-emit a flat compound symbol."""
+    """Inverse of :func:`_tokenize_compound`: re-emit a compound symbol."""
     out = parts[0]
     for op, p in zip(operators, parts[1:]):
         out += op + p
@@ -763,15 +808,8 @@ def _best_compound_match(
     """
     Find the simplest ``a*b`` or ``a/b`` of two named units that matches
     the target dimension and SI value exactly. Both ``a`` and ``b`` must be
-    atomic (no ``*`` or ``/`` in the symbol):
-
-    * A compound divisor would be regrouped under the parser's flat,
-      left-associative grouping (``a/(b/c)`` written as ``"a/b/c"`` reads
-      back as ``a/(b*c)``).
-    * A compound numerator parses correctly but reads as something else to
-      a human (``"J/m*s"`` left-associates to ``(J/m)*s`` -- correct, but
-      looks like ``J/(m*s)``). Restricting to atomic operands keeps the
-      emitted symbol unambiguous to readers.
+    atomic (no ``*`` or ``/`` in the symbol) — a readability rule for
+    simplify's output: ``T*m`` is a simplification, ``(J/m)*s`` is not.
 
     A dimensionless target is never matched: it is a pure number, and any
     ``a*b`` / ``a/b`` reaching it would pair two same-dimension units (e.g.
@@ -851,11 +889,8 @@ def multiply_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
 
     s1 = u1.unitSymbol
     s2 = u2.unitSymbol
-    # No special case for s1 == s2: writing "s1^2" would be wrong when s1 is
-    # itself compound (e.g. "kg*m^2" parses as kg*(m^2), not (kg*m)^2), and
-    # wrapping in parens ("(s1)^2") produces a symbol the parser cannot read
-    # back. The plain "s1*s2" form always round-trips and yields the correct
-    # dimension regardless of whether either operand is atomic or compound.
+    # Products never need grouping: appended operators apply to the whole
+    # accumulated value, so "s1*s2" round-trips for any operand structure.
     symbol = s1 + "*" + s2
     d1 = u1.unitDimension
     d2 = u2.unitDimension
@@ -893,19 +928,14 @@ def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     if s1 == s2:
         symbol = "1"
     else:
-        # The parser is flat and left-associative ("a/b/c" means (a/b)/c), so
-        # writing f"{s1}/{s2}" with a *compound* divisor would regroup:
-        # V/(eV/c) emitted as "V/eV/c" reads back as V/(eV*c). Distribute the
-        # division across the divisor's tokens instead, inverting each of its
-        # operators: a/(b*c) -> a/b/c and a/(b/c) -> a/b*c. A compound
-        # numerator needs no such care — appended operators apply to the whole
-        # accumulated value under left association. An empty numerator symbol
-        # (the dimensionless identity) is emitted as "1" so the result does
-        # not start with a bare operator.
+        # A compound divisor is parenthesized so the symbol keeps its
+        # grouping when re-parsed ("a/b/c" means (a/b)/c, not a/(b/c)).
+        # The numerator never needs parens: appended operators apply to the
+        # whole accumulated value. An empty numerator symbol (the
+        # dimensionless identity) is emitted as "1".
         numerator = s1 if s1 else "1"
-        parts, ops = _tokenize_compound(s2)
-        inverted = ["/"] + ["*" if op == "/" else "/" for op in ops]
-        symbol = numerator + "".join(op + p for op, p in zip(inverted, parts))
+        divisor = s2 if _is_atomic_symbol(s2) else f"({s2})"
+        symbol = f"{numerator}/{divisor}"
     d1 = u1.unitDimension
     d2 = u2.unitDimension
     dim = tuple(a - b for a, b in zip(d1, d2))
@@ -971,10 +1001,9 @@ def power_unit(u: pmd_unit, power: float) -> pmd_unit:
     if symbol in ["", "1"]:
         new_symbol = symbol
     elif "*" in symbol or "/" in symbol:
-        # Distribute the exponent across a compound symbol. Naively writing
-        # "compound^n" is wrong: the parser is flat and left-associative, so
-        # "eV*s^2" parses as eV*(s^2), not (eV*s)^2. Instead, multiply each
-        # token's own exponent by ``power`` and re-emit.
+        # Distribute the exponent across the tokens of a compound symbol:
+        # (eV*s)^2 -> "eV^2*s^2". The distributed form is the conventional
+        # spelling and composes with existing per-token exponents.
         new_symbol = _distribute_power_in_symbol(symbol, power)
     else:
         new_symbol = _format_power(symbol, power)

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -234,8 +234,10 @@ class pmd_unit:
             result._unitSymbol = unitSymbol
             return result
 
-        # Not found anywhere
-        raise ValueError(f"Unknown unitSymbol: {unitSymbol}")
+        # Single token, not directly known: delegate to _parse_single_unit,
+        # which handles power/sqrt notation and the SI-prefix fallback (and
+        # raises "Unknown unitSymbol" if it is genuinely unparseable).
+        return cls._parse_single_unit(unitSymbol)
 
     @classmethod
     def _parse_single_unit(cls, part: str) -> pmd_unit:
@@ -287,6 +289,24 @@ class pmd_unit:
             # Recursively parse base (could be sqrt(m)^2)
             base_unit = cls._parse_single_unit(base_symbol)
             return power_unit(base_unit, power)
+
+        # SI-prefix fallback: e.g. "keV" -> kilo + "eV", "mm" -> milli + "m",
+        # "mrad" -> milli + "rad". Only matches when the remainder is itself a
+        # known unit; a bare prefix ("k", "M") or a prefixed dimensionless
+        # identity ("k1") is not a valid unit. Longest prefixes first so "da"
+        # (deca) wins over "d" (deci). This is the inverse of the prefixed
+        # symbols simplify() emits, so those always round-trip.
+        for prefix in sorted(SHORT_PREFIX_FACTOR, key=len, reverse=True):
+            if prefix == "" or not part.startswith(prefix):
+                continue
+            remainder = part[len(prefix) :]
+            if remainder in ("", "1") or remainder not in known_unit:
+                continue
+            base = known_unit[remainder]
+            factor = SHORT_PREFIX_FACTOR[prefix]
+            return cls(
+                part, unitSI=factor * base.unitSI, unitDimension=base.unitDimension
+            )
 
         # Unknown unit
         raise ValueError(f"Unknown unitSymbol: {part}")
@@ -618,14 +638,15 @@ def sqrt_unit(u: pmd_unit) -> pmd_unit:
     if not isinstance(u, pmd_unit):
         raise ValueError("`u` is not a pmd_unit instance")
 
+    # Delegate to power_unit(0.5): it halves the dimension exponents with true
+    # division (e.g. m -> m^0.5) and bypasses make_dimension, so fractional
+    # dimensions survive. (Building via pmd_unit(...) instead would route
+    # through make_dimension, which int()-truncates 0.5 back to 0.)
+    result = power_unit(u, 0.5)
     symbol = u.unitSymbol
     if symbol not in ["", "1"]:
-        symbol = rf"\sqrt{{ {symbol} }}"
-
-    unitSI = np.sqrt(u.unitSI)
-    dim = tuple(x // 2 for x in u.unitDimension)
-
-    return pmd_unit(unitSymbol=symbol, unitSI=unitSI, unitDimension=dim)
+        result._unitSymbol = rf"\sqrt{{ {symbol} }}"
+    return result
 
 
 def power_unit(u: pmd_unit, power: float) -> pmd_unit:
@@ -1063,7 +1084,10 @@ def pg_units(key: str) -> pmd_unit:
             return pg_units(nkey)
 
     if key.startswith("cov_"):
-        subkeys = key.strip("cov_").split("__")
+        # NB: removeprefix, not strip("cov_") -- str.strip removes any leading/
+        # trailing chars in the set {c,o,v,_}, which mangles subkeys like
+        # "charge" (-> "harge"). removeprefix drops exactly the "cov_" prefix.
+        subkeys = key.removeprefix("cov_").split("__")
         unit0 = PARTICLEGROUP_UNITS[subkeys[0]]
 
         unit1 = PARTICLEGROUP_UNITS[subkeys[1]]

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -34,9 +34,14 @@ Limit = tuple[Optional[float], Optional[float]]
 # path as integer ones. Equality with int tuples still works (``1.0 == 1``).
 Dimension = tuple[float, float, float, float, float, float, float]
 
-# Homoglyph folding applied to symbols on parse (after NFC normalization,
-# which already folds U+2126 OHM SIGN into U+03A9 GREEK CAPITAL OMEGA):
-# GREEK SMALL MU -> MICRO SIGN, the codepoint SHORT_PREFIX_FACTOR uses.
+# Some characters have look-alike twins in Unicode: the Greek letter µ and
+# the "micro sign", the Greek letter Ω and the "ohm sign". A pasted symbol
+# may contain either twin, and they are visually indistinguishable. The
+# parser converts each pair to the single character the unit tables use.
+# NFC normalization already converts OHM SIGN (U+2126) to GREEK CAPITAL
+# OMEGA (U+03A9); this table handles the mu pair, which NFC leaves alone:
+# GREEK SMALL MU (U+03BC) becomes MICRO SIGN (U+00B5), the character in
+# SHORT_PREFIX_FACTOR (and what Option-m types on a Mac).
 _HOMOGLYPH_TRANSLATION = str.maketrans({"μ": "µ"})
 
 # Module-level dict that will be populated after NAMED_UNITS is created
@@ -103,15 +108,15 @@ class pmd_unit:
     If unitSI=0 (default), `pmd_unit` may be initialized with a known symbol:
 
     >>> pmd_unit('T')
-    pmd_unit('T', 1, (0.0, 1.0, -2.0, -1.0, 0.0, 0.0, 0.0))
+    pmd_unit('T', 1.0, (0.0, 1.0, -2.0, -1.0, 0.0, 0.0, 0.0))
 
     Compound units can be created using * and / operators in the symbol string:
 
     >>> pmd_unit('eV/c')
-    pmd_unit('eV/c', 5.344286295439521e-28, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
+    pmd_unit('eV/c', 5.344285992678308e-28, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
 
     >>> pmd_unit('kg*m/s')
-    pmd_unit('kg*m/s', 1, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
+    pmd_unit('kg*m/s', 1.0, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
 
     Parsing is left-associative ('V/eV/c' means '(V/eV)/c'); parentheses
     group a sub-expression into a single operand:
@@ -122,11 +127,11 @@ class pmd_unit:
     Alternatively, use the `from_symbol` class method for explicit symbol lookup:
 
     >>> pmd_unit.from_symbol('A*s')
-    pmd_unit('A*s', 1, (0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0))
+    pmd_unit('A*s', 1.0, (0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0))
 
-    Equality follows the openPMD standard: the symbol is presentational and
-    two units are equal when they share the same ``unitDimension`` and
-    ``unitSI`` (compared with a small relative tolerance):
+    Equality follows the openPMD standard: the symbol is only a display
+    label, and two units are equal when they share the same ``unitDimension``
+    and ``unitSI`` (compared with a small relative tolerance):
 
     >>> pmd_unit("T") == pmd_unit("T")
     True
@@ -147,8 +152,8 @@ class pmd_unit:
         # The openPMD standard defines unitSI as a positive conversion factor
         # to the corresponding SI unit. Negative scales would invert the sign
         # of every value an instrument writes through this unit, so they are
-        # rejected here. (unitSI=0 is permitted as the sentinel that triggers
-        # symbol lookup below.)
+        # rejected here. (unitSI=0 is permitted: it means "not given", and
+        # the symbol is looked up instead, below.)
         if unitSI < 0:
             raise ValueError(
                 f"unitSI must be non-negative (got {unitSI!r}). "
@@ -160,7 +165,8 @@ class pmd_unit:
         # Otherwise look the symbol up / parse it.
         if unitSI != 0 or not known_unit:
             self._unitSymbol = unitSymbol
-            self._unitSI = unitSI
+            # float, per the openPMD standard (unitSI is a float64 attribute).
+            self._unitSI = float(unitSI)
             if isinstance(unitDimension, str):
                 self._unitDimension = dimension(unitDimension)
             else:
@@ -176,11 +182,18 @@ class pmd_unit:
         """
         Create a pmd_unit from a symbol string, with automatic lookup and parsing.
 
-        This method handles:
-        - Simple known units (e.g., 'eV', 'm', 'T')
-        - Compound expressions with operators (e.g., 'eV/c', 'kg*m/s')
-        - Power notation (e.g., 'm^2', 'eV^2', 's^-1')
-        - Square root notation (e.g., 'sqrt(m)')
+        This is the single, recursive parser. It handles:
+
+        - Known units ('eV', 'm', 'T') and aliases ('Ohm', 'deg')
+        - Compound expressions ('eV/c', 'kg*m/s') — each token recurses here
+        - Parenthesized grouping ('V/(eV/c)', '(eV*s)^2')
+        - Power notation ('m^2', 's^-1', 'm^(-3/2)')
+        - Square root notation ('sqrt(m)', 'sqrt(kg*m)')
+        - SI-prefixed known units ('keV', 'mm', 'mrad')
+
+        Every recursive call parses a strictly shorter string (a token, a
+        sqrt/group inner expression, or a power base) — never the unchanged
+        input — so parsing always terminates.
 
         Parameters
         ----------
@@ -197,21 +210,24 @@ class pmd_unit:
         ValueError
             If the symbol is not found in known_unit dict or cannot be parsed.
         """
-        # Strip outer whitespace so users can write "  eV/c" or "kg*m / s".
-        # Per-token whitespace inside the operator-split branch below is also
-        # stripped. We do not split on whitespace (no implicit space-as-*),
-        # which would conflict with multi-token named units like "charge #"
-        # and with the SI-prefix fallback ("k eV" vs "keV").
+        # Canonicalize the input:
         #
-        # Unicode homoglyphs are folded to the codepoints used by the unit
-        # tables: NFC maps U+2126 OHM SIGN to U+03A9 GREEK CAPITAL OMEGA
-        # (the codepoint Unicode itself recommends, and the one NAMED_UNITS
-        # uses), and GREEK SMALL MU (U+03BC) is translated to MICRO SIGN
-        # (U+00B5), which is what SHORT_PREFIX_FACTOR keys on.
-        unitSymbol = (
+        # - Look-alike Unicode characters are converted to the ones the
+        #   unit tables use, so a pasted Ω or µ parses no matter which of
+        #   its visually identical twins it actually is. NFC normalization
+        #   handles the ohm/omega pair; _HOMOGLYPH_TRANSLATION handles
+        #   Greek mu vs the micro sign (see its definition for details).
+        # - Outer whitespace and whitespace around "^" are stripped, so
+        #   "  eV/c", "kg*m / s", and "m ^ 2" parse like their tight forms.
+        #   We do not split on whitespace (no implicit space-as-*), which
+        #   would conflict with multi-token named units like "charge #" and
+        #   with the SI-prefix fallback ("k eV" vs "keV").
+        unitSymbol = re.sub(
+            r"\s*\^\s*",
+            "^",
             unicodedata.normalize("NFC", unitSymbol)
             .translate(_HOMOGLYPH_TRANSLATION)
-            .strip()
+            .strip(),
         )
 
         # Check if known_unit dict has been populated
@@ -221,42 +237,26 @@ class pmd_unit:
                 "Use pmd_unit(unitSymbol, unitSI, unitDimension) with explicit parameters instead."
             )
 
-        # known_unit exists - check if it's already a known unit (priority)
+        # Known unit (or alias) lookup has priority. Return a shallow copy,
+        # never the shared cached object: callers reassign ``_unitSymbol`` on
+        # the result, which would otherwise mutate the global NAMED_UNITS
+        # entry. (All three slots are immutable: str, float, tuple.)
         if unitSymbol in known_unit:
-            # Shallow copy preserves the cached dimension/SI without
-            # re-coercing through make_dimension, while still letting callers
-            # reassign _unitSymbol without mutating the shared NAMED_UNITS
-            # entry. (All three slots are immutable: str, float, tuple.)
             result = copy.copy(known_unit[unitSymbol])
             result._unitSymbol = unitSymbol
             return result
 
-        # Handle sqrt() notation: sqrt(X) = X^0.5. The stored symbol is
-        # always the canonical, whitespace-free "sqrt(<inner>)" form so that
-        # "sqrt( m )", "sqrt(m)", and "  sqrt(m)" all compare equal and hash
-        # identically.
-        sqrt_match = re.match(r"^sqrt\(\s*(.+?)\s*\)$", unitSymbol)
-        if sqrt_match:
-            inner = sqrt_match.group(1)
-            base_unit = cls.from_symbol(inner)
-            result = power_unit(base_unit, 0.5)
-            result._unitSymbol = f"sqrt({base_unit.unitSymbol})"
-            return result
-
-        # Not in known_unit - try operator parsing (e.g., "A*s", "kg*m/s", "m^2")
-        if "*" in unitSymbol or "/" in unitSymbol or "^" in unitSymbol:
-            parts, operators = _tokenize_compound(unitSymbol)
-
+        # Compound expression: split on top-level "*" and "/" (parentheses
+        # protect their contents) and recurse on each token.
+        parts, operators = _tokenize_compound(unitSymbol)
+        if len(parts) > 1:
             # Reject empty operands around an operator ("m*", "/m", "m**s").
             if any(p == "" for p in parts):
                 raise ValueError(
                     f"Malformed unit symbol {unitSymbol!r}: empty operand around an operator."
                 )
 
-            # Parse every token, then combine. A parenthesized token like
-            # "(eV/c)" recursively parses its inner expression as a unit of
-            # its own.
-            token_units = [cls._parse_single_unit(p) for p in parts]
+            token_units = [cls.from_symbol(p) for p in parts]
             result = token_units[0]
             for op, unit_obj in zip(operators, token_units[1:]):
                 if op == "*":
@@ -280,46 +280,17 @@ class pmd_unit:
             result._unitSymbol = _join_compound(canonical_parts, operators)
             return result
 
-        # Single token, not directly known: delegate to _parse_single_unit,
-        # which handles power/sqrt notation and the SI-prefix fallback (and
-        # raises "Unknown unitSymbol" if it is genuinely unparseable).
-        return cls._parse_single_unit(unitSymbol)
+        # --- Single token from here on. ---
 
-    @classmethod
-    def _parse_single_unit(cls, part: str) -> pmd_unit:
-        """
-        Parse a single unit that may include a power (e.g., 'm^2', 'eV', 's^-1')
-        or sqrt notation (e.g., 'sqrt(m)').
-
-        Parameters
-        ----------
-        part : str
-            A single unit token, optionally with power or sqrt notation.
-
-        Returns
-        -------
-        pmd_unit
-            The parsed unit object.
-        """
-        # Strip whitespace around the token and around any "^" so callers can
-        # write "m ^ 2" or "  m^2" interchangeably with "m^2".
-        part = re.sub(r"\s*\^\s*", "^", part.strip())
-
-        # Check if it's a known unit first. Return a shallow copy, never the
-        # shared cached object: callers (e.g. from_symbol) reassign
-        # ``_unitSymbol`` on the result, which would otherwise mutate the
-        # global NAMED_UNITS entry.
-        if part in known_unit:
-            result = copy.copy(known_unit[part])
-            result._unitSymbol = part
-            return result
-
-        # Check for sqrt() notation. Whitespace inside the parens is stripped
-        # and the stored symbol is canonicalized to "sqrt(<inner>)".
-        sqrt_match = re.match(r"^sqrt\(\s*(.+?)\s*\)$", part)
-        if sqrt_match:
-            inner = sqrt_match.group(1)
-            base_unit = cls._parse_single_unit(inner)
+        # sqrt() notation: sqrt(X) = X^0.5. The stored symbol is always the
+        # canonical, whitespace-free "sqrt(<inner>)" form so that "sqrt( m )"
+        # and "sqrt(m)" compare equal and hash identically. The
+        # balanced-parens guard keeps a product like "sqrt(m)*sqrt(m)" (whose
+        # final ")" is not the partner of the first "(") from being consumed
+        # as one sqrt.
+        sqrt_match = re.match(r"^sqrt\(\s*(.+?)\s*\)$", unitSymbol)
+        if sqrt_match and _parens_balanced(sqrt_match.group(1)):
+            base_unit = cls.from_symbol(sqrt_match.group(1))
             result = power_unit(base_unit, 0.5)
             result._unitSymbol = f"sqrt({base_unit.unitSymbol})"
             return result
@@ -330,28 +301,36 @@ class pmd_unit:
         # base recursion lands back here). The balanced-parens guard keeps
         # adjacent groups with no operator, like "(a)(b)", from matching as
         # one group with inner "a)(b".
-        paren_group_match = re.match(r"^\((.+)\)$", part)
+        paren_group_match = re.match(r"^\((.+)\)$", unitSymbol)
         if paren_group_match and _parens_balanced(paren_group_match.group(1)):
-            return cls.from_symbol(paren_group_match.group(1))
+            result = cls.from_symbol(paren_group_match.group(1))
+            # Preserve the grouping in the stored symbol unless it is
+            # redundant: "(eV/c)" stays, "(m)" canonicalizes to "m".
+            s = result.unitSymbol
+            if not _is_atomic_symbol(s):
+                result._unitSymbol = f"({s})"
+            return result
 
-        # Check for power notation with parenthesized fraction: m^(-3/2)
-        paren_power_match = re.match(r"^(.+)\^\((-?\d+)/(\d+)\)$", part)
+        # Power notation with a parenthesized fraction: m^(-3/2)
+        paren_power_match = re.match(r"^(.+)\^\((-?\d+)/(\d+)\)$", unitSymbol)
         if paren_power_match:
-            base_symbol = paren_power_match.group(1)
-            numerator = int(paren_power_match.group(2))
-            denominator = int(paren_power_match.group(3))
-            power = numerator / denominator
-            base_unit = cls._parse_single_unit(base_symbol)
-            return power_unit(base_unit, power)
+            power = int(paren_power_match.group(2)) / int(paren_power_match.group(3))
+            base_unit = cls.from_symbol(paren_power_match.group(1))
+            result = power_unit(base_unit, power)
+            # Preserve the user's spelling ("m^(1/2)", not "m^0.5").
+            result._unitSymbol = unitSymbol
+            return result
 
-        # Check for power notation: m^2, m^-1, m^0.5
-        power_match = re.match(r"^(.+)\^(-?\d+(?:\.\d+)?)$", part)
+        # Power notation: m^2, m^-1, m^0.5 (the base recurses, so sqrt(m)^2
+        # and (eV*s)^2 work)
+        power_match = re.match(r"^(.+)\^(-?\d+(?:\.\d+)?)$", unitSymbol)
         if power_match:
-            base_symbol = power_match.group(1)
-            power = float(power_match.group(2))
-            # Recursively parse base (could be sqrt(m)^2)
-            base_unit = cls._parse_single_unit(base_symbol)
-            return power_unit(base_unit, power)
+            base_unit = cls.from_symbol(power_match.group(1))
+            result = power_unit(base_unit, float(power_match.group(2)))
+            # Preserve the user's spelling ("(eV*s)^2", not the distributed
+            # "eV^2*s^2" that power_unit emits).
+            result._unitSymbol = unitSymbol
+            return result
 
         # SI-prefix fallback: e.g. "keV" -> kilo + "eV", "mm" -> milli + "m",
         # "mrad" -> milli + "rad". Only matches when the remainder is itself a
@@ -360,27 +339,28 @@ class pmd_unit:
         # (deca) wins over "d" (deci). This is the inverse of the prefixed
         # symbols simplify() emits, so those always round-trip.
         for prefix in sorted(SHORT_PREFIX_FACTOR, key=len, reverse=True):
-            if prefix == "" or not part.startswith(prefix):
+            if prefix == "" or not unitSymbol.startswith(prefix):
                 continue
-            remainder = part[len(prefix) :]
+            remainder = unitSymbol[len(prefix) :]
             if remainder in ("", "1") or remainder not in known_unit:
                 continue
             base = known_unit[remainder]
             factor = SHORT_PREFIX_FACTOR[prefix]
             return cls(
-                part, unitSI=factor * base.unitSI, unitDimension=base.unitDimension
+                unitSymbol,
+                unitSI=factor * base.unitSI,
+                unitDimension=base.unitDimension,
             )
 
         # Unknown unit
-        raise ValueError(f"Unknown unitSymbol: {part}")
+        raise ValueError(f"Unknown unitSymbol: {unitSymbol}")
 
     def __hash__(self) -> int:
         # The openPMD standard defines a unit by its dimension and conversion
-        # factor; the symbol is only presentational and is excluded here. Both
-        # defining fields contribute to the hash, using the same rounded
-        # conversion factor that __eq__ compares, so equal units always hash
-        # alike while units that merely share a dimension (such as eV and J)
-        # fall into different buckets.
+        # factor; the symbol is only a display label and is excluded here.
+        # The hash uses the same rounded conversion factor that __eq__
+        # compares, so equal units always hash alike, while units that merely
+        # share a dimension (such as eV and J) hash differently.
         return hash((self.unitDimension, _canonical_unitSI(self.unitSI)))
 
     @property
@@ -477,13 +457,13 @@ class pmd_unit:
         return self.unitSI / other.unitSI
 
     def __eq__(self, other) -> bool:
-        # Per the openPMD standard, a unit is defined by its conversion factor
-        # and dimension; the symbol is only a presentational hint. Two units
+        # Per the openPMD standard, a unit is defined by its conversion
+        # factor and dimension; the symbol is only a display label. Two units
         # are therefore equal when their dimensions match and their conversion
-        # factors agree once rounded to the canonical precision. Rounding lets
-        # values that differ only by the rounding error of arithmetic such as
-        # (eV/c) * c -> eV still compare equal, and keeps this comparison
-        # consistent with __hash__.
+        # factors agree after rounding (_canonical_unitSI, shared with
+        # __hash__). The rounding lets results of arithmetic like
+        # (eV/c) * c -> eV compare equal to eV despite tiny floating-point
+        # differences.
         if not isinstance(other, self.__class__):
             return False
         if self.unitDimension != other.unitDimension:
@@ -664,14 +644,16 @@ def _canonical_unitSI(unitSI: float) -> float:
 
     Two units are considered equal when they share a dimension and their
     rounded conversion factors are identical. Rounding to a fixed precision is
-    deliberate: it makes equality transitive, which ``math.isclose`` is not. A
-    transitive equality is what lets ``__hash__`` safely depend on the
-    conversion factor as well as the dimension. Were the hash to use the raw
-    factor, two units that compare equal but whose factors differ in their last
-    bits could hash differently and break the rule that equal objects must
-    share a hash. Folding the factor into the key (instead of hashing on the
-    dimension alone) keeps units of the same dimension but different scale,
-    such as ``eV`` and ``J``, in separate hash buckets.
+    deliberate: it makes equality transitive (if a == b and b == c then
+    a == c), which a tolerance comparison like ``math.isclose`` cannot
+    guarantee — two values can each be within tolerance of a middle value but
+    not of each other. Transitivity is what lets ``__hash__`` include the
+    conversion factor: were the hash to use the raw factor, two units that
+    compare equal but differ in the last few bits could hash differently,
+    breaking the rule that equal objects must hash equal. Including the
+    factor in the hash (rather than hashing on the dimension alone) keeps
+    units of the same dimension but different scale, such as ``eV`` and
+    ``J``, from all colliding.
 
     Zero and non-finite factors are returned unchanged, since they have no
     meaningful significant-figure representation.
@@ -889,8 +871,9 @@ def multiply_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
 
     s1 = u1.unitSymbol
     s2 = u2.unitSymbol
-    # Products never need grouping: appended operators apply to the whole
-    # accumulated value, so "s1*s2" round-trips for any operand structure.
+    # Products never need parentheses: an operator appended on the right
+    # acts on everything to its left, so "s1*s2" reads back correctly no
+    # matter what s1 and s2 contain.
     symbol = s1 + "*" + s2
     d1 = u1.unitDimension
     d2 = u2.unitDimension
@@ -928,11 +911,11 @@ def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     if s1 == s2:
         symbol = "1"
     else:
-        # A compound divisor is parenthesized so the symbol keeps its
-        # grouping when re-parsed ("a/b/c" means (a/b)/c, not a/(b/c)).
-        # The numerator never needs parens: appended operators apply to the
-        # whole accumulated value. An empty numerator symbol (the
-        # dimensionless identity) is emitted as "1".
+        # A divisor that itself contains operators must be parenthesized,
+        # because "a/b/c" reads back as (a/b)/c, not a/(b/c). The numerator
+        # never needs parens: an operator appended on the right acts on
+        # everything to its left. A numerator with an empty symbol (the
+        # dimensionless unit) is written as "1".
         numerator = s1 if s1 else "1"
         divisor = s2 if _is_atomic_symbol(s2) else f"({s2})"
         symbol = f"{numerator}/{divisor}"
@@ -989,7 +972,7 @@ def power_unit(u: pmd_unit, power: float) -> pmd_unit:
     Examples
     --------
     >>> power_unit(pmd_unit("m"), 2)
-    pmd_unit('m^2', 1, (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+    pmd_unit('m^2', 1.0, (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
 
     >>> power_unit(pmd_unit("m"), 0.5)
     pmd_unit('m^0.5', 1.0, (0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
@@ -1101,7 +1084,9 @@ def make_dimension(dim: Sequence[int | float]) -> Dimension:
 
 def dimension(name: str) -> Dimension | None:
     try:
-        return DIMENSION[name]
+        # Coerce to the canonical float form so every construction path
+        # (string name or explicit tuple) yields the same Dimension type.
+        return make_dimension(DIMENSION[name])
     except KeyError:
         options = ", ".join(DIMENSION)
         raise ValueError(
@@ -1201,13 +1186,13 @@ def unit(symbol: str) -> pmd_unit:
 
     Examples
     --------
-    Old style (deprecated):
+    Old style (deprecated)::
 
-        >>> unit("eV/c")
+        unit("eV/c")
 
-    New style (preferred):
+    New style (preferred)::
 
-        >>> pmd_unit("eV/c")
+        pmd_unit("eV/c")
     """
     warnings.warn(
         "unit() is deprecated. Use pmd_unit() directly instead.",
@@ -1296,7 +1281,7 @@ def nice_scale_prefix(scale: float) -> tuple[float, str]:
     """
 
     if scale == 0:
-        return 1, ""
+        return 1.0, ""
 
     p10 = np.log10(abs(scale))
 
@@ -1309,6 +1294,8 @@ def nice_scale_prefix(scale: float) -> tuple[float, str]:
     else:
         f = 1
 
+    # Plain Python float (np.log10 produces np.float64 otherwise).
+    f = float(f)
     return f, SHORT_PREFIX[f]
 
 
@@ -1418,8 +1405,10 @@ for k in ["theta", "bunching_phase"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("rad")
 for k in ["charge", "species_charge", "weight"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("C")
-for k in ["average_current"]:
+for k in ["average_current", "current"]:  # 'current' appears in slice statistics
     PARTICLEGROUP_UNITS[k] = pmd_unit("A")
+for k in ["density"]:  # slice statistics: charge per slice length
+    PARTICLEGROUP_UNITS[k] = pmd_unit("C") / pmd_unit("m")
 for k in ["power"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("W")
 for k in ["norm_emit_x", "norm_emit_y"]:
@@ -1497,7 +1486,8 @@ def parse_bunching_str(s):
     wavelength: float
 
     """
-    assert s.startswith("bunching_")
+    if not s.startswith("bunching_"):
+        raise ValueError(f"Invalid bunching key: {s!r} (must start with 'bunching_')")
 
     # Remove bunching and phase prefixes
     s = s.replace("bunching_", "")
@@ -1533,11 +1523,14 @@ def parse_bunching_str(s):
 
 def write_unit_h5(h5, u):
     """
-    Writes an pmd_unit to an h5 handle
+    Writes a pmd_unit to an h5 handle.
+
+    ``unitSI`` and ``unitDimension`` are written as float64 per the openPMD
+    standard; ``unitSymbol`` as a UTF-8 string (it may contain e.g. 'Ω', 'µ').
     """
 
-    h5.attrs["unitSI"] = u.unitSI
-    h5.attrs["unitDimension"] = u.unitDimension
+    h5.attrs["unitSI"] = float(u.unitSI)
+    h5.attrs["unitDimension"] = np.asarray(u.unitDimension, dtype=np.float64)
     h5.attrs["unitSymbol"] = u.unitSymbol
 
 
@@ -1553,6 +1546,11 @@ def read_unit_h5(h5):
         unitSymbol = "unknown"
     else:
         unitSymbol = a["unitSymbol"]
+        # Files written with fixed-length/bytes string attrs (e.g. via
+        # np.bytes_) yield bytes here; a str symbol is required for unit
+        # arithmetic and to_tex.
+        if isinstance(unitSymbol, bytes):
+            unitSymbol = unitSymbol.decode("utf-8")
 
     return pmd_unit(unitSymbol=unitSymbol, unitSI=unitSI, unitDimension=unitDimension)
 

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -624,6 +624,8 @@ NAMED_UNITS = [
     pmd_unit("W/rad^2", 1, (2, 1, -3, 0, 0, 0, 0)),
     pmd_unit("W/m^2", 1, (0, 1, -3, 0, 0, 0, 0)),
     pmd_unit("T", 1, "magnetic_field"),
+    pmd_unit("T/m", 1, (-1, 1, -2, -1, 0, 0, 0)),
+    pmd_unit("Hz", 1, (0, 0, -1, 0, 0, 0, 0)),
 ]
 
 # Populate the module-level known_unit dict
@@ -634,6 +636,7 @@ known_unit.update(
         "1": pmd_unit("", 1, "1"),
         "charge_num": pmd_unit("charge #", 1, "charge"),
         "c_light": pmd_unit("vel/c", c_light, "velocity"),
+        "deg": known_unit["degree"],
     }
 )
 

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -7,6 +7,7 @@ For more advanced units, use a package like Pint:
 
 from __future__ import annotations
 
+import math
 import re
 import warnings
 from typing import Optional, Sequence
@@ -324,31 +325,51 @@ class pmd_unit:
 
     def simplify(self, named_units=None) -> pmd_unit:
         """
-        Tries to simplify a unit by searching from a list of named units
-        for the same unitDimension and unitSI.
-        """
+        Search for a simpler equivalent symbol with the same dimension and
+        SI value as this unit.
 
-        # Use default
+        The search proceeds in two passes:
+
+        1. **Atomic match.** Look for a single entry in ``named_units`` whose
+           dimension matches ``self.unitDimension`` and whose ``unitSI``
+           equals ``self.unitSI`` (optionally up to a single SI prefix
+           factor from :data:`SHORT_PREFIX_FACTOR`). Comparisons use
+           ``math.isclose`` so factors built from arithmetic are matched
+           reliably.
+        2. **Compound match.** If no atomic match is found, look for an
+           ``a*b`` or ``a/b`` combination of two named units (both with
+           nonzero dimension) whose product/quotient matches ``self`` exactly.
+
+        Among candidates, the one with the simplest symbol is returned
+        (no operators preferred; then shortest; then lexicographic).
+        If nothing matches, ``self`` is returned unchanged.
+
+        Parameters
+        ----------
+        named_units : sequence of pmd_unit, optional
+            Pool of named units to search. Defaults to :data:`NAMED_UNITS`.
+
+        Returns
+        -------
+        pmd_unit
+            A simplified unit, or ``self`` if no simplification was found.
+        """
         if named_units is None:
             named_units = NAMED_UNITS
 
-        unitDimension = self.unitDimension
-        unitSI = self.unitSI
+        target_dim = self.unitDimension
+        target_si = self.unitSI
 
-        # find any dimensional matches
-        matches = [u0 for u0 in named_units if unitDimension == u0.unitDimension]
-        # Look for exact unit
-        for match in matches:
-            factor = unitSI / match.unitSI
-            if factor == 1:
-                return match
-            if factor in SHORT_PREFIX:
-                p = SHORT_PREFIX[factor]
-                return pmd_unit(
-                    p + match.unitSymbol, factor * match.unitSI, match.unitDimension
-                )
+        # Pass 1: single named-unit match (optionally with an SI prefix).
+        atomic = _best_atomic_match(target_dim, target_si, named_units)
+        if atomic is not None:
+            return atomic
 
-        # No match, cannot simplify
+        # Pass 2: a*b or a/b compound match (exact SI, no extra prefix).
+        compound = _best_compound_match(target_dim, target_si, named_units)
+        if compound is not None:
+            return compound
+
         return self
 
 
@@ -364,6 +385,114 @@ def is_identity(u: pmd_unit) -> bool:
     if not isinstance(u, pmd_unit):
         raise ValueError("`u` is not a pmd_unit instance")
     return u.unitSI == 1 and u.unitDimension == (0, 0, 0, 0, 0, 0, 0)
+
+
+_SIMPLIFY_REL_TOL = 1e-9
+_DIMENSIONLESS: Dimension = (0, 0, 0, 0, 0, 0, 0)
+
+
+def _symbol_complexity(symbol: str) -> tuple[int, int, str]:
+    """Sort key: prefer no operators, then shorter, then lexicographic."""
+    has_ops = any(c in symbol for c in "*/^")
+    return (int(has_ops), len(symbol), symbol)
+
+
+def _closest_prefix(factor: float) -> tuple[str, float] | None:
+    """
+    Return ``(prefix, prefix_factor)`` from :data:`SHORT_PREFIX_FACTOR` if
+    ``factor`` matches a known SI prefix within :data:`_SIMPLIFY_REL_TOL`,
+    else ``None``.
+    """
+    if math.isclose(factor, 1.0, rel_tol=_SIMPLIFY_REL_TOL):
+        return ("", 1.0)
+    for prefix, pf in SHORT_PREFIX_FACTOR.items():
+        if math.isclose(factor, pf, rel_tol=_SIMPLIFY_REL_TOL):
+            return (prefix, pf)
+    return None
+
+
+def _best_atomic_match(
+    target_dim: Dimension,
+    target_si: float,
+    named_units: Sequence[pmd_unit],
+) -> pmd_unit | None:
+    """
+    Find the simplest named unit (optionally with an SI prefix) whose
+    dimension and SI value match the target.
+    """
+    candidates: list[tuple[int, tuple[int, int, str], pmd_unit, str, float]] = []
+    for u in named_units:
+        if u.unitDimension != target_dim or u.unitSI == 0:
+            continue
+        prefix_match = _closest_prefix(target_si / u.unitSI)
+        if prefix_match is None:
+            continue
+        prefix, pf = prefix_match
+        out_symbol = prefix + u.unitSymbol
+        # Priority: exact match (priority 0) beats prefixed match (priority 1).
+        priority = 0 if prefix == "" else 1
+        candidates.append((priority, _symbol_complexity(out_symbol), u, prefix, pf))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda c: (c[0], c[1]))
+    _, _, u, prefix, pf = candidates[0]
+    if prefix == "":
+        return u
+    return pmd_unit(prefix + u.unitSymbol, pf * u.unitSI, u.unitDimension)
+
+
+def _best_compound_match(
+    target_dim: Dimension,
+    target_si: float,
+    named_units: Sequence[pmd_unit],
+) -> pmd_unit | None:
+    """
+    Find the simplest ``a*b`` or ``a/b`` of two named units that matches
+    the target dimension and SI value exactly. Dimensionless factors are
+    skipped to avoid trivial decorations like ``"m*1"``.
+    """
+    dim_index: dict[Dimension, list[pmd_unit]] = {}
+    for u in named_units:
+        if u.unitDimension == _DIMENSIONLESS or u.unitSI == 0:
+            continue
+        dim_index.setdefault(u.unitDimension, []).append(u)
+
+    if not dim_index or target_si == 0:
+        return None
+
+    best: pmd_unit | None = None
+    best_key: tuple[int, int, str] | None = None
+
+    for a in (u for group in dim_index.values() for u in group):
+        a_si = a.unitSI
+
+        # self = a * b  =>  b_dim = target - a_dim, b_si = target / a
+        mul_dim = tuple(td - ad for td, ad in zip(target_dim, a.unitDimension))
+        mul_target_si = target_si / a_si
+        for b in dim_index.get(mul_dim, ()):
+            if not math.isclose(b.unitSI, mul_target_si, rel_tol=_SIMPLIFY_REL_TOL):
+                continue
+            sym = f"{a.unitSymbol}*{b.unitSymbol}"
+            key = _symbol_complexity(sym)
+            if best_key is None or key < best_key:
+                best = pmd_unit(sym, a_si * b.unitSI, target_dim)
+                best_key = key
+
+        # self = a / b  =>  b_dim = a_dim - target, b_si = a / target
+        div_dim = tuple(ad - td for ad, td in zip(a.unitDimension, target_dim))
+        div_target_si = a_si / target_si
+        for b in dim_index.get(div_dim, ()):
+            if not math.isclose(b.unitSI, div_target_si, rel_tol=_SIMPLIFY_REL_TOL):
+                continue
+            sym = f"{a.unitSymbol}/{b.unitSymbol}"
+            key = _symbol_complexity(sym)
+            if best_key is None or key < best_key:
+                best = pmd_unit(sym, a_si / b.unitSI, target_dim)
+                best_key = key
+
+    return best
 
 
 def multiply_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
@@ -543,7 +672,7 @@ DIMENSION: dict[str, Dimension] = {
     #
     "charge": (0, 0, 1, 1, 0, 0, 0),
     "electric_field": (1, 1, -3, -1, 0, 0, 0),
-    "electric_potential": (1, 2, -3, -1, 0, 0, 0),
+    "electric_potential": (2, 1, -3, -1, 0, 0, 0),
     "magnetic_field": (0, 1, -2, -1, 0, 0, 0),
     "velocity": (1, 0, -1, 0, 0, 0, 0),
     "energy": (2, 1, -2, 0, 0, 0, 0),
@@ -624,7 +753,6 @@ NAMED_UNITS = [
     pmd_unit("W/rad^2", 1, (2, 1, -3, 0, 0, 0, 0)),
     pmd_unit("W/m^2", 1, (0, 1, -3, 0, 0, 0, 0)),
     pmd_unit("T", 1, "magnetic_field"),
-    pmd_unit("T/m", 1, (-1, 1, -2, -1, 0, 0, 0)),
     pmd_unit("Hz", 1, (0, 0, -1, 0, 0, 0, 0)),
 ]
 

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -335,12 +335,13 @@ class pmd_unit:
         raise ValueError(f"Unknown unitSymbol: {part}")
 
     def __hash__(self) -> int:
-        # The openPMD standard defines a unit by (unitSI, unitDimension); the
-        # symbol is presentational. Hash on unitDimension alone so that any
-        # two equal units (per __eq__'s isclose comparison on unitSI) share a
-        # hash bucket — preserving the hash/eq invariant even when unitSI
-        # values arrived via slightly different arithmetic paths.
-        return hash(self.unitDimension)
+        # The openPMD standard defines a unit by its dimension and conversion
+        # factor; the symbol is only presentational and is excluded here. Both
+        # defining fields contribute to the hash, using the same rounded
+        # conversion factor that __eq__ compares, so equal units always hash
+        # alike while units that merely share a dimension (such as eV and J)
+        # fall into different buckets.
+        return hash((self.unitDimension, _canonical_unitSI(self.unitSI)))
 
     @property
     def unitSymbol(self) -> str:
@@ -436,19 +437,18 @@ class pmd_unit:
         return self.unitSI / other.unitSI
 
     def __eq__(self, other) -> bool:
-        # Per the openPMD standard, a unit is defined by (unitSI,
-        # unitDimension); the symbol is a presentational hint. Two units are
-        # equal when both fields match, with math.isclose on unitSI to
-        # absorb floating-point drift from arithmetic like
-        # (eV/c) * c -> eV (the eV value reconstructed through c_light
-        # round-tripping may differ from e_charge by 1 ULP).
+        # Per the openPMD standard, a unit is defined by its conversion factor
+        # and dimension; the symbol is only a presentational hint. Two units
+        # are therefore equal when their dimensions match and their conversion
+        # factors agree once rounded to the canonical precision. Rounding lets
+        # values that differ only by the rounding error of arithmetic such as
+        # (eV/c) * c -> eV still compare equal, and keeps this comparison
+        # consistent with __hash__.
         if not isinstance(other, self.__class__):
             return False
         if self.unitDimension != other.unitDimension:
             return False
-        return math.isclose(
-            self.unitSI, other.unitSI, rel_tol=_SIMPLIFY_REL_TOL, abs_tol=0.0
-        )
+        return _canonical_unitSI(self.unitSI) == _canonical_unitSI(other.unitSI)
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
@@ -601,6 +601,37 @@ def is_identity(u: pmd_unit) -> bool:
 _SIMPLIFY_REL_TOL = 1e-9
 _DIMENSIONLESS: Dimension = (0, 0, 0, 0, 0, 0, 0)
 
+# Number of significant figures to which unitSI is rounded before it is
+# compared or hashed. Twelve figures is precise enough to keep genuinely
+# different conversion factors apart (for example eV versus J, or meters
+# versus kilometers) while remaining coarse enough to ignore the tiny
+# rounding error that ordinary unit arithmetic introduces -- reconstructing
+# eV via (eV/c) * c, for instance, lands within roughly one part in 1e16 of
+# the original value.
+_UNITSI_SIG_FIGS = 12
+
+
+def _canonical_unitSI(unitSI: float) -> float:
+    """Round ``unitSI`` to a canonical value used by both ``__eq__`` and ``__hash__``.
+
+    Two units are considered equal when they share a dimension and their
+    rounded conversion factors are identical. Rounding to a fixed precision is
+    deliberate: it makes equality transitive, which ``math.isclose`` is not. A
+    transitive equality is what lets ``__hash__`` safely depend on the
+    conversion factor as well as the dimension. Were the hash to use the raw
+    factor, two units that compare equal but whose factors differ in their last
+    bits could hash differently and break the rule that equal objects must
+    share a hash. Folding the factor into the key (instead of hashing on the
+    dimension alone) keeps units of the same dimension but different scale,
+    such as ``eV`` and ``J``, in separate hash buckets.
+
+    Zero and non-finite factors are returned unchanged, since they have no
+    meaningful significant-figure representation.
+    """
+    if unitSI == 0 or not math.isfinite(unitSI):
+        return unitSI
+    return float(f"{unitSI:.{_UNITSI_SIG_FIGS - 1}e}")
+
 
 def _tokenize_compound(symbol: str) -> tuple[list[str], list[str]]:
     """Split ``symbol`` on top-level ``*`` and ``/`` (respecting parentheses).
@@ -688,7 +719,7 @@ def _best_atomic_match(
             continue
         prefix, pf = prefix_match
         # A prefix on a dimensionless unit is meaningless: the empty symbol
-        # becomes a bare prefix ("" -> "m", which re-parses as metres), and
+        # becomes a bare prefix ("" -> "m", which re-parses as meters), and
         # "mrad"/"krad" would imply an angle for a pure-number ratio. Only an
         # exact (unprefixed) dimensionless match is valid.
         if prefix != "" and u.unitDimension == _DIMENSIONLESS:

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -25,7 +25,12 @@ epsilon_0 = 1 / (mu_0 * c_light**2)  # F/m
 Z0 = mu_0 * c_light  # Omh = V^2/W
 
 Limit = tuple[Optional[float], Optional[float]]
-Dimension = tuple[int, int, int, int, int, int, int]
+# 7-tuple of base-SI exponents (length, mass, time, current, temperature,
+# mol, luminous). The openPMD standard specifies ``unitDimension`` as an
+# array of 7 float64 values, so we store floats uniformly — this also lets
+# fractional powers (e.g. from sqrt_unit) round-trip through the same code
+# path as integer ones. Equality with int tuples still works (``1.0 == 1``).
+Dimension = tuple[float, float, float, float, float, float, float]
 
 # Module-level dict that will be populated after NAMED_UNITS is created
 # This avoids the globals() check chicken-and-egg problem
@@ -86,24 +91,25 @@ class pmd_unit:
     Define that an eV is 1.602176634e-19 of base units m^2 kg/s^2, which is a Joule (J):
 
     >>> pmd_unit('eV', 1.602176634e-19, (2, 1, -2, 0, 0, 0, 0))
+    pmd_unit('eV', 1.602176634e-19, (2.0, 1.0, -2.0, 0.0, 0.0, 0.0, 0.0))
 
     If unitSI=0 (default), `pmd_unit` may be initialized with a known symbol:
 
     >>> pmd_unit('T')
-    pmd_unit('T', 1, (0, 1, -2, -1, 0, 0, 0))
+    pmd_unit('T', 1, (0.0, 1.0, -2.0, -1.0, 0.0, 0.0, 0.0))
 
     Compound units can be created using * and / operators in the symbol string:
 
     >>> pmd_unit('eV/c')
-    pmd_unit('eV/c', 5.344286295439521e-28, (1, 1, -1, 0, 0, 0, 0))
+    pmd_unit('eV/c', 5.344286295439521e-28, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
 
     >>> pmd_unit('kg*m/s')
-    pmd_unit('kg*m/s', 1, (1, 1, -1, 0, 0, 0, 0))
+    pmd_unit('kg*m/s', 1, (1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0))
 
     Alternatively, use the `from_symbol` class method for explicit symbol lookup:
 
     >>> pmd_unit.from_symbol('A*s')
-    pmd_unit('A*s', 1, (0, 0, 1, 1, 0, 0, 0))
+    pmd_unit('A*s', 1, (0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0))
 
     Simple equalities are possible:
 
@@ -117,7 +123,7 @@ class pmd_unit:
         self,
         unitSymbol: str = "",
         unitSI: int | float = 0,
-        unitDimension: str | Dimension | tuple[int, ...] = (0, 0, 0, 0, 0, 0, 0),
+        unitDimension: str | Sequence[int | float] = (0, 0, 0, 0, 0, 0, 0),
     ):
         # Use the provided values directly when unitSI is given explicitly, or
         # while NAMED_UNITS is still being built (known_unit not yet populated).
@@ -134,21 +140,6 @@ class pmd_unit:
             self._unitSymbol = u._unitSymbol
             self._unitSI = u._unitSI
             self._unitDimension = u._unitDimension
-
-    @classmethod
-    def _raw(cls, unitSymbol: str, unitSI: float, unitDimension: Dimension) -> pmd_unit:
-        """
-        Construct a unit directly from its parts, bypassing ``make_dimension``.
-
-        Used by the arithmetic helpers (``multiply_units`` / ``divide_units`` /
-        ``power_unit``) where the dimension is already computed and may be
-        fractional (which ``make_dimension`` would truncate to ``int``).
-        """
-        u = object.__new__(cls)
-        u._unitSymbol = unitSymbol
-        u._unitSI = unitSI
-        u._unitDimension = unitDimension
-        return u
 
     @classmethod
     def from_symbol(cls, unitSymbol: str) -> pmd_unit:
@@ -587,7 +578,7 @@ def multiply_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     dim = tuple(sum(x) for x in zip(d1, d2))
     unitSI = u1.unitSI * u2.unitSI
 
-    return pmd_unit._raw(symbol, unitSI, dim)
+    return pmd_unit(symbol, unitSI=unitSI, unitDimension=dim)
 
 
 def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
@@ -624,7 +615,7 @@ def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     dim = tuple(a - b for a, b in zip(d1, d2))
     unitSI = u1.unitSI / u2.unitSI
 
-    return pmd_unit._raw(symbol, unitSI, dim)
+    return pmd_unit(symbol, unitSI=unitSI, unitDimension=dim)
 
 
 def sqrt_unit(u: pmd_unit) -> pmd_unit:
@@ -643,10 +634,6 @@ def sqrt_unit(u: pmd_unit) -> pmd_unit:
     if not isinstance(u, pmd_unit):
         raise ValueError("`u` is not a pmd_unit instance")
 
-    # Delegate to power_unit(0.5): it halves the dimension exponents with true
-    # division (e.g. m -> m^0.5) and bypasses make_dimension, so fractional
-    # dimensions survive. (Building via pmd_unit(...) instead would route
-    # through make_dimension, which int()-truncates 0.5 back to 0.)
     result = power_unit(u, 0.5)
     symbol = u.unitSymbol
     if symbol not in ["", "1"]:
@@ -673,10 +660,10 @@ def power_unit(u: pmd_unit, power: float) -> pmd_unit:
     Examples
     --------
     >>> power_unit(pmd_unit("m"), 2)
-    pmd_unit('m^2', 1, (2, 0, 0, 0, 0, 0, 0))
+    pmd_unit('m^2', 1, (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
 
     >>> power_unit(pmd_unit("m"), 0.5)
-    pmd_unit('m^0.5', 1, (0.5, 0, 0, 0, 0, 0, 0))
+    pmd_unit('m^0.5', 1.0, (0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
     """
     if not isinstance(u, pmd_unit):
         raise ValueError("`u` is not a pmd_unit instance")
@@ -690,10 +677,9 @@ def power_unit(u: pmd_unit, power: float) -> pmd_unit:
         new_symbol = f"{symbol}^{power}"
 
     unitSI = u.unitSI**power
-    # Scale each dimension by the power (preserves fractional dimensions)
     dim = tuple(d * power for d in u.unitDimension)
 
-    return pmd_unit._raw(new_symbol, unitSI, dim)
+    return pmd_unit(new_symbol, unitSI=unitSI, unitDimension=dim)
 
 
 # length mass time current temperature mol luminous
@@ -720,8 +706,17 @@ DIMENSION: dict[str, Dimension] = {
 DIMENSION_NAME: dict[Dimension, str] = {v: k for k, v in DIMENSION.items()}
 
 
-def make_dimension(dim: Sequence[int]) -> Dimension:
-    dim = tuple(int(d) for d in dim)
+def make_dimension(dim: Sequence[int | float]) -> Dimension:
+    """
+    Coerce a 7-element sequence of base-SI exponents into the canonical
+    ``Dimension`` form: a 7-tuple of floats.
+
+    The openPMD standard defines ``unitDimension`` as an array of 7
+    ``float64`` values, so floats are used uniformly here. This also lets
+    fractional exponents (e.g. from :func:`sqrt_unit`) share a single
+    representation with integer ones.
+    """
+    dim = tuple(float(d) for d in dim)
     if len(dim) != 7:
         raise ValueError("Dimensions must be 7 elements.")
     return dim

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -253,9 +253,12 @@ class pmd_unit:
         pmd_unit
             The parsed unit object.
         """
-        # Check if it's a known unit first
+        # Check if it's a known unit first. Return a copy, never the shared
+        # cached object: callers (e.g. from_symbol) reassign ``_unitSymbol`` on
+        # the result, which would otherwise mutate the global NAMED_UNITS entry.
         if part in known_unit:
-            return known_unit[part]
+            u = known_unit[part]
+            return cls(part, unitSI=u.unitSI, unitDimension=u.unitDimension)
 
         # Check for sqrt() notation
         sqrt_match = re.match(r"^sqrt\((.+)\)$", part)
@@ -428,6 +431,12 @@ def _best_atomic_match(
         if prefix_match is None:
             continue
         prefix, pf = prefix_match
+        # A prefix on a dimensionless unit is meaningless: the empty symbol
+        # becomes a bare prefix ("" -> "m", which re-parses as metres), and
+        # "mrad"/"krad" would imply an angle for a pure-number ratio. Only an
+        # exact (unprefixed) dimensionless match is valid.
+        if prefix != "" and u.unitDimension == _DIMENSIONLESS:
+            continue
         out_symbol = prefix + u.unitSymbol
         # Priority: exact match (priority 0) beats prefixed match (priority 1).
         priority = 0 if prefix == "" else 1
@@ -452,6 +461,13 @@ def _best_compound_match(
     Find the simplest ``a*b`` or ``a/b`` of two named units that matches
     the target dimension and SI value exactly. Dimensionless factors are
     skipped to avoid trivial decorations like ``"m*1"``.
+
+    The symbol parser is flat and left-associative (``a/b/c`` means
+    ``(a/b)/c``), so a divisor that itself contains ``*`` or ``/`` would be
+    regrouped when the symbol is re-parsed (``a/(b/c)`` written as
+    ``"a/b/c"`` reads back as ``a/(b*c)``). The ``a/b`` form therefore only
+    accepts an operator-free divisor; the ``a*b`` form is unaffected because
+    a product chain is associative under the parser's grouping.
     """
     dim_index: dict[Dimension, list[pmd_unit]] = {}
     for u in named_units:
@@ -484,6 +500,9 @@ def _best_compound_match(
         div_dim = tuple(ad - td for ad, td in zip(a.unitDimension, target_dim))
         div_target_si = a_si / target_si
         for b in dim_index.get(div_dim, ()):
+            # An operator-containing divisor would be regrouped on re-parse.
+            if any(op in b.unitSymbol for op in "*/"):
+                continue
             if not math.isclose(b.unitSI, div_target_si, rel_tol=_SIMPLIFY_REL_TOL):
                 continue
             sym = f"{a.unitSymbol}/{b.unitSymbol}"

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -447,8 +447,13 @@ def _best_atomic_match(
     """
     Find the simplest named unit (optionally with an SI prefix) whose
     dimension and SI value match the target.
+
+    Sort key: exact match beats prefixed, then no operators preferred, then
+    shorter, then lexicographic.
     """
-    candidates: list[tuple[int, tuple[int, int, str], pmd_unit, str, float]] = []
+    best: pmd_unit | None = None
+    best_key: tuple[int, int, int, str] | None = None
+
     for u in named_units:
         if u.unitDimension != target_dim or u.unitSI == 0:
             continue
@@ -462,19 +467,19 @@ def _best_atomic_match(
         # exact (unprefixed) dimensionless match is valid.
         if prefix != "" and u.unitDimension == _DIMENSIONLESS:
             continue
+
         out_symbol = prefix + u.unitSymbol
-        # Priority: exact match (priority 0) beats prefixed match (priority 1).
         priority = 0 if prefix == "" else 1
-        candidates.append((priority, _symbol_complexity(out_symbol), u, prefix, pf))
+        key = (priority, *_symbol_complexity(out_symbol))
+        if best_key is not None and key >= best_key:
+            continue
 
-    if not candidates:
-        return None
+        best = (
+            u if prefix == "" else pmd_unit(out_symbol, pf * u.unitSI, u.unitDimension)
+        )
+        best_key = key
 
-    candidates.sort(key=lambda c: (c[0], c[1]))
-    _, _, u, prefix, pf = candidates[0]
-    if prefix == "":
-        return u
-    return pmd_unit(prefix + u.unitSymbol, pf * u.unitSI, u.unitDimension)
+    return best
 
 
 def _best_compound_match(

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -119,8 +119,10 @@ class pmd_unit:
         unitSI: int | float = 0,
         unitDimension: str | Dimension | tuple[int, ...] = (0, 0, 0, 0, 0, 0, 0),
     ):
-        # If unitSI is provided explicitly, use it directly
-        if unitSI != 0:
+        # Use the provided values directly when unitSI is given explicitly, or
+        # while NAMED_UNITS is still being built (known_unit not yet populated).
+        # Otherwise look the symbol up / parse it.
+        if unitSI != 0 or not known_unit:
             self._unitSymbol = unitSymbol
             self._unitSI = unitSI
             if isinstance(unitDimension, str):
@@ -128,22 +130,25 @@ class pmd_unit:
             else:
                 self._unitDimension = make_dimension(unitDimension)
         else:
-            # unitSI == 0: try to lookup/parse the symbol
-            # Check if known_unit dict has been populated (it won't during NAMED_UNITS construction)
-            if not known_unit:
-                # During NAMED_UNITS construction - just use what's provided
-                self._unitSymbol = unitSymbol
-                self._unitSI = unitSI
-                if isinstance(unitDimension, str):
-                    self._unitDimension = dimension(unitDimension)
-                else:
-                    self._unitDimension = make_dimension(unitDimension)
-            else:
-                # known_unit exists - delegate to from_symbol for lookup/parsing
-                u = self.from_symbol(unitSymbol)
-                self._unitSymbol = u._unitSymbol
-                self._unitSI = u._unitSI
-                self._unitDimension = u._unitDimension
+            u = self.from_symbol(unitSymbol)
+            self._unitSymbol = u._unitSymbol
+            self._unitSI = u._unitSI
+            self._unitDimension = u._unitDimension
+
+    @classmethod
+    def _raw(cls, unitSymbol: str, unitSI: float, unitDimension: Dimension) -> pmd_unit:
+        """
+        Construct a unit directly from its parts, bypassing ``make_dimension``.
+
+        Used by the arithmetic helpers (``multiply_units`` / ``divide_units`` /
+        ``power_unit``) where the dimension is already computed and may be
+        fractional (which ``make_dimension`` would truncate to ``int``).
+        """
+        u = object.__new__(cls)
+        u._unitSymbol = unitSymbol
+        u._unitSI = unitSI
+        u._unitDimension = unitDimension
+        return u
 
     @classmethod
     def from_symbol(cls, unitSymbol: str) -> pmd_unit:
@@ -577,13 +582,7 @@ def multiply_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     dim = tuple(sum(x) for x in zip(d1, d2))
     unitSI = u1.unitSI * u2.unitSI
 
-    # Bypass make_dimension to preserve fractional dimensions
-    result = object.__new__(pmd_unit)
-    result._unitSymbol = symbol
-    result._unitSI = unitSI
-    result._unitDimension = dim
-
-    return result
+    return pmd_unit._raw(symbol, unitSI, dim)
 
 
 def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
@@ -620,13 +619,7 @@ def divide_units(u1: pmd_unit, u2: pmd_unit) -> pmd_unit:
     dim = tuple(a - b for a, b in zip(d1, d2))
     unitSI = u1.unitSI / u2.unitSI
 
-    # Bypass make_dimension to preserve fractional dimensions
-    result = object.__new__(pmd_unit)
-    result._unitSymbol = symbol
-    result._unitSI = unitSI
-    result._unitDimension = dim
-
-    return result
+    return pmd_unit._raw(symbol, unitSI, dim)
 
 
 def sqrt_unit(u: pmd_unit) -> pmd_unit:
@@ -695,14 +688,7 @@ def power_unit(u: pmd_unit, power: float) -> pmd_unit:
     # Scale each dimension by the power (preserves fractional dimensions)
     dim = tuple(d * power for d in u.unitDimension)
 
-    # Create unit object without going through make_dimension
-    # to preserve fractional dimensions
-    result = object.__new__(pmd_unit)
-    result._unitSymbol = new_symbol
-    result._unitSI = unitSI
-    result._unitDimension = dim
-
-    return result
+    return pmd_unit._raw(new_symbol, unitSI, dim)
 
 
 # length mass time current temperature mol luminous
@@ -1054,9 +1040,9 @@ for k in ["power"]:
 for k in ["norm_emit_x", "norm_emit_y"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("m")
 for k in ["norm_emit_4d"]:
-    PARTICLEGROUP_UNITS[k] = multiply_units(pmd_unit("m"), pmd_unit("m"))
+    PARTICLEGROUP_UNITS[k] = pmd_unit("m") * pmd_unit("m")
 for k in ["Lz"]:
-    PARTICLEGROUP_UNITS[k] = multiply_units(pmd_unit("m"), pmd_unit("eV/c"))
+    PARTICLEGROUP_UNITS[k] = pmd_unit("m") * pmd_unit("eV/c")
 for k in ["xp", "yp"]:
     PARTICLEGROUP_UNITS[k] = pmd_unit("rad")
 for k in ["x_bar", "px_bar", "y_bar", "py_bar"]:
@@ -1072,9 +1058,7 @@ for plane in ("x", "y"):
     for k in ("beta", "eta", "emit", "norm_emit"):
         PARTICLEGROUP_UNITS[f"twiss_{k}_{plane}"] = pmd_unit("m")
     for k in ("gamma",):
-        PARTICLEGROUP_UNITS[f"twiss_{k}_{plane}"] = divide_units(
-            pmd_unit("1"), pmd_unit("m")
-        )
+        PARTICLEGROUP_UNITS[f"twiss_{k}_{plane}"] = pmd_unit("1") / pmd_unit("m")
 
 
 def pg_units(key: str) -> pmd_unit:
@@ -1097,11 +1081,7 @@ def pg_units(key: str) -> pmd_unit:
         # trailing chars in the set {c,o,v,_}, which mangles subkeys like
         # "charge" (-> "harge"). removeprefix drops exactly the "cov_" prefix.
         subkeys = key.removeprefix("cov_").split("__")
-        unit0 = PARTICLEGROUP_UNITS[subkeys[0]]
-
-        unit1 = PARTICLEGROUP_UNITS[subkeys[1]]
-
-        return multiply_units(unit0, unit1)
+        return PARTICLEGROUP_UNITS[subkeys[0]] * PARTICLEGROUP_UNITS[subkeys[1]]
 
     # Fields
     if key.startswith("electricField"):
@@ -1220,7 +1200,7 @@ def read_dataset_and_unit_h5(h5, expected_unit=None, convert=True):
         expected_unit = pmd_unit(expected_unit)
 
     # Check dimensions
-    du = divide_units(u, expected_unit)
+    du = u / expected_unit
 
     assert du.unitDimension == (0, 0, 0, 0, 0, 0, 0), "incompatible units"
 

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -488,7 +488,14 @@ def _best_compound_match(
     ``"a/b/c"`` reads back as ``a/(b*c)``). The ``a/b`` form therefore only
     accepts an operator-free divisor; the ``a*b`` form is unaffected because
     a product chain is associative under the parser's grouping.
+
+    A dimensionless target is never matched: it is a pure number, and any
+    ``a*b`` / ``a/b`` reaching it would pair two same-dimension units (e.g.
+    ``kg/g`` for a ratio of 1000), which is meaningless as a unit symbol.
     """
+    if target_dim == _DIMENSIONLESS:
+        return None
+
     dim_index: dict[Dimension, list[pmd_unit]] = {}
     for u in named_units:
         if u.unitDimension == _DIMENSIONLESS or u.unitSI == 0:
@@ -794,6 +801,7 @@ NAMED_UNITS = [
     pmd_unit("W/m^2", 1, (0, 1, -3, 0, 0, 0, 0)),
     pmd_unit("T", 1, "magnetic_field"),
     pmd_unit("Hz", 1, (0, 0, -1, 0, 0, 0, 0)),
+    pmd_unit("Ω", 1, (2, 1, -3, -2, 0, 0, 0)),  # ohm = V/A; used for impedance
 ]
 
 # Populate the module-level known_unit dict
@@ -805,6 +813,7 @@ known_unit.update(
         "charge_num": pmd_unit("charge #", 1, "charge"),
         "c_light": pmd_unit("vel/c", c_light, "velocity"),
         "deg": known_unit["degree"],
+        "Ohm": known_unit["Ω"],  # ASCII alias for the ohm
     }
 )
 

--- a/beamphysics/units.py
+++ b/beamphysics/units.py
@@ -160,10 +160,9 @@ class pmd_unit:
                 "The openPMD standard defines unitSI as a conversion factor to SI."
             )
 
-        # Use the provided values directly when unitSI is given explicitly, or
-        # while NAMED_UNITS is still being built (known_unit not yet populated).
-        # Otherwise look the symbol up / parse it.
-        if unitSI != 0 or not known_unit:
+        # Use the provided values directly when unitSI is given explicitly;
+        # otherwise look the symbol up / parse it.
+        if unitSI != 0:
             self._unitSymbol = unitSymbol
             # float, per the openPMD standard (unitSI is a float64 attribute).
             self._unitSI = float(unitSI)
@@ -470,9 +469,6 @@ class pmd_unit:
             return False
         return _canonical_unitSI(self.unitSI) == _canonical_unitSI(other.unitSI)
 
-    def __ne__(self, other) -> bool:
-        return not self.__eq__(other)
-
     def __str__(self) -> str:
         return self.unitSymbol
 
@@ -561,6 +557,50 @@ class pmd_unit:
         '\\\\sqrt{\\\\mathrm{m}}'
         """
         return _symbol_to_tex(self._unitSymbol)
+
+    def scaled_symbol(self, factor: float) -> str:
+        """Display symbol for ``factor`` times this unit.
+
+        The spelling is kept whenever an SI prefix can express the factor
+        directly on it: ``pmd_unit("eV/c").scaled_symbol(1e-3)`` is
+        ``'meV/c'``. When it cannot, the scaled value is matched against
+        the named units (``1e-6 * mA*s`` scales to ``'nC'``, ``1e3 * 1/s``
+        to ``'kHz'``), and failing that the factor is written out:
+        ``pmd_unit("m^2").scaled_symbol(1e-3)`` is ``'1e-3 m^2'`` (a glued
+        ``'mm^2'`` would read as ``(mm)^2``, the wrong value).
+
+        ``factor`` is typically a power of ten from :func:`nice_array`,
+        :func:`nice_scale_prefix`, or :func:`plottable_array`.
+        """
+        if factor == 1:
+            return self.unitSymbol
+        if self.unitSymbol in ("", "1"):
+            # Dimensionless: the scale is a pure number.
+            return _format_scale(factor)
+
+        # Keep the spelling: glue an SI prefix when the combined string
+        # reads back as the same unit scaled by the factor.
+        prefix = SHORT_PREFIX.get(float(factor))
+        if prefix:
+            try:
+                candidate = pmd_unit(prefix + self.unitSymbol)
+                if candidate.compatible_with(self) and math.isclose(
+                    candidate.unitSI,
+                    factor * self.unitSI,
+                    rel_tol=_SIMPLIFY_REL_TOL,
+                ):
+                    return prefix + self.unitSymbol
+            except (ValueError, KeyError):
+                pass
+
+        # Re-spell: the scaled value may be a named or prefixed unit.
+        scaled = pmd_unit(
+            "<scaled>", factor * self.unitSI, self.unitDimension
+        ).simplify()
+        if scaled.unitSymbol != "<scaled>":
+            return scaled.unitSymbol
+
+        return f"{_format_scale(factor)} {self.unitSymbol}"
 
 
 def _symbol_to_tex(symbol: str) -> str:
@@ -1082,7 +1122,7 @@ def make_dimension(dim: Sequence[int | float]) -> Dimension:
     return dim
 
 
-def dimension(name: str) -> Dimension | None:
+def dimension(name: str) -> Dimension:
     try:
         # Coerce to the canonical float form so every construction path
         # (string name or explicit tuple) yields the same Dimension type.
@@ -1202,32 +1242,7 @@ def unit(symbol: str) -> pmd_unit:
     return pmd_unit(symbol)
 
 
-# Dicts for prefixes
-PREFIX_FACTOR: dict[str, float] = {
-    "yocto-": 1e-24,
-    "zepto-": 1e-21,
-    "atto-": 1e-18,
-    "femto-": 1e-15,
-    "pico-": 1e-12,
-    "nano-": 1e-9,
-    "micro-": 1e-6,
-    "milli-": 1e-3,
-    "centi-": 1e-2,
-    "deci-": 1e-1,
-    "deca-": 1e1,
-    "hecto-": 1e2,
-    "kilo-": 1e3,
-    "mega-": 1e6,
-    "giga-": 1e9,
-    "tera-": 1e12,
-    "peta-": 1e15,
-    "exa-": 1e18,
-    "zetta-": 1e21,
-    "yotta-": 1e24,
-}
-# Inverse
-PREFIX: dict[float, str] = dict((v, k) for k, v in PREFIX_FACTOR.items())
-
+# SI prefixes
 SHORT_PREFIX_FACTOR: dict[str, float] = {
     "y": 1e-24,
     "z": 1e-21,
@@ -1256,6 +1271,15 @@ SHORT_PREFIX: dict[float, str] = dict((v, k) for k, v in SHORT_PREFIX_FACTOR.ite
 
 
 # Nice scaling
+
+
+def _format_scale(factor: float) -> str:
+    """'1e-3' for powers of ten, plain '%g' formatting otherwise."""
+    if factor > 0:
+        n = round(math.log10(factor))
+        if math.isclose(factor, 10.0**n, rel_tol=1e-12):
+            return f"1e{n}"
+    return f"{factor:g}"
 
 
 def nice_scale_prefix(scale: float) -> tuple[float, str]:
@@ -1377,6 +1401,54 @@ def plottable_array(x: np.ndarray, nice: bool = True, lim: Limit | None = None):
         factor, p1 = 1, ""
 
     return x / factor, factor, p1, xmin, xmax
+
+
+def plottable_array_and_units(
+    x: np.ndarray, units=None, nice: bool = True, lim: Limit | None = None
+):
+    """
+    Scale an array for plotting and return its display units in one step.
+
+    Combines :func:`plottable_array` with :meth:`pmd_unit.scaled_symbol`,
+    so the caller never handles a bare SI prefix: the array comes back
+    scaled and the units string already says what the scaled values mean
+    ('µm', 'keV/c', '1e-3 m^2'). A string that is not a parseable unit
+    symbol is kept verbatim with the factor written out ('1e3 counts').
+
+    Parameters
+    ----------
+    x : array-like
+    units : pmd_unit or str, optional
+        The unit of the raw values. If None, the units string is the bare
+        prefix (or None when there is no scaling).
+    nice : bool, default = True
+        Scale array by some nice factor.
+    lim : tuple, default = None
+        Limits to consider for the scaling, as in :func:`plottable_array`.
+
+    Returns
+    -------
+    scaled_array : np.ndarray
+    factor : float
+    units_str : str or None
+        Display units of the scaled values.
+    xmin : float
+    xmax : float
+    """
+    x, factor, prefix, xmin, xmax = plottable_array(x, nice=nice, lim=lim)
+    if units is None or str(units) == "":
+        units_str = prefix or None
+    else:
+        try:
+            u = units if isinstance(units, pmd_unit) else pmd_unit(str(units))
+        except (ValueError, KeyError):
+            # Not a unit symbol: keep the text, note the scale.
+            units_str = (
+                str(units) if factor == 1 else f"{_format_scale(factor)} {units}"
+            )
+        else:
+            units_str = u.scaled_symbol(factor)
+    return x, factor, units_str, xmin, xmax
 
 
 # -------------------------

--- a/beamphysics/writers.py
+++ b/beamphysics/writers.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .readers import component_from_alias, load_field_attrs
 from .tools import encode_attrs, fstr
-from .units import pg_units
+from .units import pg_units, write_unit_h5
 
 
 def pmd_init(h5, basePath="/data/%T/", particlesPath="./"):
@@ -145,8 +145,6 @@ def write_component_data(h5, name, data, unit=None):
         g = h5[name]
 
     if unit:
-        g.attrs["unitSI"] = unit.unitSI
-        g.attrs["unitDimension"] = unit.unitDimension
-        g.attrs["unitSymbol"] = fstr(unit.unitSymbol)
+        write_unit_h5(g, unit)
 
     return g

--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -17,21 +17,8 @@
    },
    "outputs": [],
    "source": [
-    "# Useful for debugging\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from beamphysics import particle_paths\n",
     "from beamphysics.units import pmd_unit, NAMED_UNITS, dimension_name, sqrt_unit\n",
+    "from beamphysics import particle_paths\n",
     "from h5py import File"
    ]
   },
@@ -77,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Special function for sqrt:"
+    "Special function for `sqrt`. It halves the dimension exponents, so the result can carry fractional dimensions:"
    ]
   },
   {
@@ -101,43 +88,58 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Integer and decimal powers:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Integer and decimal powers\n",
     "pmd_unit(\"m^2\"), pmd_unit(\"m^-1\"), pmd_unit(\"m^0.5\")"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fractional powers using parentheses, e.g. `m^(-3/2)`, `m^(1/2)`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Fractional powers using parentheses: m^(-3/2), m^(1/2)\n",
     "pmd_unit(\"m^(-3/2)\"), pmd_unit(\"m^(3/2)\")"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`sqrt()` notation is equivalent to `^(1/2)`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sqrt() notation is equivalent to ^(1/2)\n",
     "pmd_unit(\"sqrt(m)\"), pmd_unit(\"m^(1/2)\")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Powers work in compound expressions\n",
-    "pmd_unit(\"eV/c*m^(-1/2)\")"
+    "Powers work in compound expressions:"
    ]
   },
   {
@@ -146,7 +148,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Check that fractional dimensions are preserved\n",
+    "pmd_unit(\"eV/c*m^(-1/2)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fractional dimensions are preserved:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "u = pmd_unit(\"m^(-3/2)\")\n",
     "u.unitDimension  # Length dimension is -1.5"
    ]
@@ -188,12 +205,85 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# SI prefixes\n",
+    "\n",
+    "Any known unit symbol may carry a standard SI prefix (`k`, `M`, `G`, `T`, `m`, `µ`, `n`, ...). The prefix scales `unitSI` and leaves the dimension unchanged:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"keV\"), pmd_unit(\"mm\"), pmd_unit(\"GHz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prefixes also apply to the dimensionless angle units `rad` and `degree` (e.g. milliradians):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"mrad\"), pmd_unit(\"µrad\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A prefix is only accepted when the remainder is itself a known unit, and a bare prefix is **not** a unit. Symbols that are both a prefix letter and a unit keep their unit meaning — `c` is the speed of light (not centi) and `T` is tesla (not tera):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"c\"), pmd_unit(\"T\")  # the units, not centi-/tera-"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A bare prefix, or a prefixed dimensionless identity, is rejected:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for s in [\"k\", \"M\", \"k1\"]:\n",
+    "    try:\n",
+    "        pmd_unit(s)\n",
+    "    except ValueError as ex:\n",
+    "        print(f\"{s!r} -> {type(ex).__name__}: {ex}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# `.simplify()`\n",
-    "The `.simplify()` method will search through an internal `NAMED_UNITS` list to find the same unit with a simplified symbol. This can resolve the symbol of multiplied and divided units. \n",
     "\n",
-    "SI prefixes will also be identified.\n",
+    "The `.simplify()` method searches the internal `NAMED_UNITS` list for an equivalent unit with a simpler symbol. It can:\n",
     "\n",
-    "Note that this is very basic, and is not called by default. "
+    "- collapse a product or quotient to a single named unit (`W*s` &rarr; `J`, `V*A` &rarr; `W`, `J/C` &rarr; `V`);\n",
+    "- reconstruct an `a*b` / `a/b` compound when no single name exists (e.g. `T*m`, `T/m`);\n",
+    "- attach an SI prefix when the value is an exact power-of-ten multiple of a named unit (`1000 J` &rarr; `kJ`).\n",
+    "\n",
+    "Matching is float-tolerant and deterministic (the simplest symbol wins), and the resulting symbol always re-parses back to the same unit. `.simplify()` is not called automatically."
    ]
   },
   {
@@ -207,13 +297,52 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A product or quotient of named units, or a reconstructed compound:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    (pmd_unit(\"V\") * pmd_unit(\"A\")).simplify(),  # -> W\n",
+    "    (pmd_unit(\"J\") / pmd_unit(\"C\")).simplify(),  # -> V\n",
+    "    (pmd_unit(\"T\") * pmd_unit(\"m\")).simplify(),  # -> T*m (no single name)\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "u = pmd_unit(\"this should be kJ\", 1e3, (2, 1, -2, 0, 0, 0, 0))\n",
-    "u.simplify()"
+    "simplified = u.simplify()\n",
+    "\n",
+    "# The simplified symbol re-parses back to the same unit:\n",
+    "simplified, pmd_unit(simplified.unitSymbol)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A purely dimensionless quantity has no meaningful named form, so `.simplify()` leaves it unchanged rather than inventing a same-dimension ratio. For example, `mrad/µrad` is just the number `1000`, and it is **not** rewritten as `kg/g`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"mrad/µrad\").simplify()  # 1000, dimensionless -> unchanged"
    ]
   },
   {
@@ -421,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Units\n",
     "\n",
-    "This package provides unit conversion tools "
+    "Simple unit tools following the openPMD standard: a unit is defined by a conversion factor to SI (`unitSI`), a 7-component dimension tuple (`unitDimension`), and a presentational symbol (`unitSymbol`)."
    ]
   },
   {
@@ -61,6 +61,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Unit arithmetic\n",
+    "\n",
     "Named units can be multiplied, divided, and raised to a power (`*`, `/`, `**`):"
    ]
   },
@@ -105,7 +107,7 @@
    },
    "outputs": [],
    "source": [
-    "# All four spellings parse; the last two are equivalent.\n",
+    "# All of these spellings parse; the last two are equivalent.\n",
     "{s: pmd_unit(s) for s in [\"m^2\", \"m^-1\", \"m^(3/2)\", \"sqrt(m)\", \"m^(1/2)\"]}"
    ]
   },
@@ -113,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `**` operator (or `power_unit(u, n)`) raises a unit to a power. For compound symbols the exponent is distributed across each token, so `(eV*s) ** 2` yields `eV^2*s^2` — not `eV*s^2`, which the flat parser would read as `eV*(s^2)`:"
+    "The `**` operator (or `power_unit(u, n)`) raises a unit to a power. For compound symbols the exponent is distributed across each token, so `pmd_unit(\"eV*s\") ** 2` yields `eV^2*s^2` (the equivalent grouped spelling `(eV*s)^2` is also accepted as input — see the next section):"
    ]
   },
   {
@@ -136,8 +138,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Parenthesized grouping\n",
+    "\n",
+    "Parsing is left-associative: `V/eV/c` means `(V/eV)/c`. Parentheses group a sub-expression into a single operand, so `V/(eV/c)` divides by `eV/c` as a whole and `(eV*s)^2` exponentiates the whole product. Groups nest, and dividing two `pmd_unit` objects parenthesizes a compound divisor automatically so the resulting symbol re-parses to the same unit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    pmd_unit(\"V/(eV/c)\"),\n",
+    "    pmd_unit(\"V/eV/c\"),  # different grouping -> different unit\n",
+    "    pmd_unit(\"(eV*s)^2\"),\n",
+    "    pmd_unit(\"V/m\") / pmd_unit(\"eV/c\"),  # division emits the parenthesized form\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Whitespace normalizes, and redundant parens around an atomic unit are dropped:\n",
+    "pmd_unit(\"V / ( eV / c )\").unitSymbol, pmd_unit(\"V/(m)\").unitSymbol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Named units\n",
-    "The package knows the following units with these symbol named "
+    "\n",
+    "The package knows the following named units:"
    ]
   },
   {
@@ -813,7 +849,6 @@
    "outputs": [],
    "source": [
     "x = 1e-4\n",
-    "unit = \"m\"\n",
     "nice_array(x)"
    ]
   },
@@ -874,7 +909,7 @@
    "source": [
     "# TeX rendering for plot labels\n",
     "\n",
-    "`pmd_unit.to_tex()` translates the stored symbol into a matplotlib-mathtext fragment. The translation is **purely structural** — no algebraic simplification, no reordering: each atomic name is wrapped in `\\mathrm{...}`, `*` becomes `{\\cdot}`, `/` stays, `^N` becomes `^{N}`, and `sqrt(X)` becomes `\\sqrt{...}` (recursing on the inner expression).\n"
+    "`pmd_unit.to_tex()` translates the stored symbol into a matplotlib-mathtext fragment. The translation is **purely structural** — no algebraic simplification, no reordering: each atomic name is wrapped in `\\mathrm{...}`, `*` becomes `{\\cdot}`, `/` stays, `^N` becomes `^{N}`, `sqrt(X)` becomes `\\sqrt{...}`, and a parenthesized group keeps its parens (recursing on the inner expression in both cases)."
    ]
   },
   {
@@ -890,7 +925,16 @@
    },
    "outputs": [],
    "source": [
-    "for s in [\"eV/c\", \"kg*m/s\", \"m^2\", \"s^-1\", \"m^(1/2)\", \"sqrt(m)\", \"sqrt(kg*m)\"]:\n",
+    "for s in [\n",
+    "    \"eV/c\",\n",
+    "    \"kg*m/s\",\n",
+    "    \"m^2\",\n",
+    "    \"s^-1\",\n",
+    "    \"m^(1/2)\",\n",
+    "    \"sqrt(m)\",\n",
+    "    \"sqrt(kg*m)\",\n",
+    "    \"V/(eV/c)\",\n",
+    "]:\n",
     "    print(f\"{s:>12}  ->  {pmd_unit(s).to_tex()}\")"
    ]
   },

--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -13,11 +13,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.261363Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.261163Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.425497Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.425206Z"
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from beamphysics.units import pmd_unit, NAMED_UNITS, dimension_name, sqrt_unit\n",
+    "from beamphysics.units import (\n",
+    "    NAMED_UNITS,\n",
+    "    dimension_name,\n",
+    "    pmd_unit,\n",
+    "    power_unit,\n",
+    "    sqrt_unit,\n",
+    ")\n",
     "from beamphysics import particle_paths\n",
     "from h5py import File"
    ]
@@ -33,6 +45,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.426880Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.426758Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.429772Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.429506Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -51,6 +69,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.448148Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.448021Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.450898Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.450664Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -58,6 +82,38 @@
     "u1 = pmd_unit(\"J\")\n",
     "u2 = pmd_unit(\"m\")\n",
     "u1, u2, u1 / u2, u1 * u2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.451887Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.451801Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.453715Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.453508Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"W/sqrt(Hz)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.454743Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.454670Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.456591Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.456367Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "(pmd_unit(\"W/sqrt(m)\") * pmd_unit(\"sqrt(m)\")).simplify()"
    ]
   },
   {
@@ -71,6 +127,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.457635Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.457565Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.459337Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.459130Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -97,7 +159,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.460346Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.460281Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.462089Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.461852Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"m^2\"), pmd_unit(\"m^-1\"), pmd_unit(\"m^0.5\")"
@@ -113,7 +182,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.463205Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.463136Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.464897Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.464715Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"m^(-3/2)\"), pmd_unit(\"m^(3/2)\")"
@@ -129,7 +205,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.465842Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.465780Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.467444Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.467267Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"sqrt(m)\"), pmd_unit(\"m^(1/2)\")"
@@ -145,7 +228,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.468373Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.468298Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.469793Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.469623Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"eV/c*m^(-1/2)\")"
@@ -161,11 +251,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.470759Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.470685Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.472547Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.472364Z"
+    }
+   },
    "outputs": [],
    "source": [
     "u = pmd_unit(\"m^(-3/2)\")\n",
     "u.unitDimension  # Length dimension is -1.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`power_unit(u, n)` raises a unit to an arbitrary power. For a compound symbol, the exponent is distributed across each token — so `(eV*s)^2` produces `eV^2*s^2`, with the dimension multiplied through correctly (and not the malformed `eV*s^2`, which the flat left-associative parser would read as `eV*(s^2)`):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.473506Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.473443Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.475164Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.474969Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "power_unit(pmd_unit(\"eV*s\"), 2), power_unit(pmd_unit(\"m^2*s^-1\"), 3)"
    ]
   },
   {
@@ -178,7 +298,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.476116Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.476055Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.477535Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.477347Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"W*s\")"
@@ -195,11 +322,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.478499Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.478432Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.480289Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.480059Z"
+    }
+   },
    "outputs": [],
    "source": [
     "NAMED_UNITS"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A few common ASCII aliases are accepted as alternate spellings of the named units (the canonical symbol is preserved in the stored `unitSymbol`, so the alias and the canonical form compare equal):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.481357Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.481287Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.483231Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.483028Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"Ohm\"), pmd_unit(\"Ω\"), pmd_unit(\"deg\"), pmd_unit(\"degree\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -213,7 +377,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.484247Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.484184Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.485965Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.485766Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"keV\"), pmd_unit(\"mm\"), pmd_unit(\"GHz\")"
@@ -229,7 +400,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.486918Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.486856Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.488536Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.488326Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"mrad\"), pmd_unit(\"µrad\")"
@@ -245,7 +423,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.489530Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.489471Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.491110Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.490909Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"c\"), pmd_unit(\"T\")  # the units, not centi-/tera-"
@@ -261,7 +446,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.492047Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.491981Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.493614Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.493426Z"
+    }
+   },
    "outputs": [],
    "source": [
     "for s in [\"k\", \"M\", \"k1\"]:\n",
@@ -289,7 +481,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.494541Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.494480Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.496250Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.496043Z"
+    }
+   },
    "outputs": [],
    "source": [
     "u = pmd_unit(\"W*s\")\n",
@@ -306,7 +505,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.497197Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.497135Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.499142Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.498949Z"
+    }
+   },
    "outputs": [],
    "source": [
     "(\n",
@@ -319,7 +525,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.500018Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.499958Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.501735Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.501561Z"
+    }
+   },
    "outputs": [],
    "source": [
     "u = pmd_unit(\"this should be kJ\", 1e3, (2, 1, -2, 0, 0, 0, 0))\n",
@@ -339,10 +552,233 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.502602Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.502542Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.504121Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.503936Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pmd_unit(\"mrad/µrad\").simplify()  # 1000, dimensionless -> unchanged"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Canonical symbols, equality, and validation\n",
+    "\n",
+    "The parser normalizes whitespace around operators (and inside `sqrt(...)`) on the way in, so all the spellings below produce the same stored symbol — and therefore compare equal and hash identically:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.505092Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.505020Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.506775Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.506597Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "spellings = [\"eV/c\", \"eV / c\", \"  eV/c  \", \"eV /c\"]\n",
+    "[pmd_unit(s).unitSymbol for s in spellings]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.507653Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.507592Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.509361Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.509197Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "a, b = pmd_unit(\"eV / c\"), pmd_unit(\"eV/c\")\n",
+    "a == b, hash(a) == hash(b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Whitespace inside `sqrt(...)` is also normalized:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.510277Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.510217Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.511886Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.511694Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"sqrt( m )\").unitSymbol, pmd_unit(\"sqrt( m )\") == pmd_unit(\"sqrt(m)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Malformed inputs — empty operands around an operator, or repeated operators — are rejected rather than silently parsing via the identity:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.512997Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.512923Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.514632Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.514442Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "for s in [\"m*\", \"/m\", \"m//s\", \"m**s\", r\"\\sqrt{m}\"]:\n",
+    "    try:\n",
+    "        pmd_unit(s)\n",
+    "    except ValueError as ex:\n",
+    "        print(f\"{s!r:>14} -> ValueError: {ex}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The openPMD standard defines `unitSI` as a non-negative conversion factor to SI, and the constructor enforces that:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.515546Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.515481Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.516945Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.516766Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    pmd_unit(\"bogus\", unitSI=-1.0, unitDimension=\"1\")\n",
+    "except ValueError as ex:\n",
+    "    print(f\"ValueError: {ex}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Value-based equality\n",
+    "\n",
+    "The openPMD standard defines a unit by its `unitSI` and `unitDimension` — the symbol is purely presentational. `pmd_unit.__eq__` follows that convention: two units compare equal when they share the same dimension and (within a small relative tolerance) the same SI factor, regardless of how their symbols were spelled.\n",
+    "\n",
+    "So different syntactic spellings of the same physical unit are equal:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.517855Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.517796Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.519514Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.519336Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"1/s\") == pmd_unit(\"Hz\"), pmd_unit(\"s^-1\") == pmd_unit(\"Hz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Arithmetic round-trips survive floating-point drift — `(eV/c) * c` reconstructs `eV` even though the intermediate float math doesn't reproduce `e_charge` bit-exactly:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.520510Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.520451Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.522156Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.521961Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "roundtrip = pmd_unit(\"eV/c\") * pmd_unit(\"c\")\n",
+    "roundtrip, roundtrip == pmd_unit(\"eV\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Same dimension but different SI scale stays unequal (`J` and `eV` are both energies, but `1 J ≠ 1 eV`):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.523056Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.522994Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.524507Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.524340Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pmd_unit(\"J\") == pmd_unit(\"eV\"), pmd_unit(\"J/m\") == pmd_unit(\"eV/m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The hash/eq invariant is preserved — equal units share a hash bucket, so they de-duplicate correctly in sets and dicts:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.525478Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.525405Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.527107Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.526942Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "hash(pmd_unit(\"1/s\")) == hash(pmd_unit(\"Hz\")), len({pmd_unit(\"1/s\"), pmd_unit(\"Hz\")})"
    ]
   },
   {
@@ -358,6 +794,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.528012Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.527953Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.530334Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.530152Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -382,7 +824,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.531267Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.531205Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.532954Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.532748Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ph5 = h5[ppaths[0]]\n",
@@ -400,6 +849,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.533836Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.533777Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.535969Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.535776Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -412,6 +867,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.536898Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.536837Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.538475Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.538296Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -430,6 +891,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.539380Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.539309Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.540869Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.540705Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -448,6 +915,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.541798Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.541738Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.543036Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.542839Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -466,6 +939,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.543916Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.543857Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.545473Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.545282Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -479,6 +958,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.546536Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.546450Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.548377Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.548201Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -490,6 +975,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.549291Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.549231Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.550578Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.550409Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -501,11 +992,92 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.551475Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.551416Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.553022Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.552836Z"
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
     "nice_scale_prefix(0.009)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TeX rendering for plot labels\n",
+    "\n",
+    "`pmd_unit.to_tex()` translates the stored symbol into a matplotlib-mathtext fragment. The translation is **purely structural** — no algebraic simplification, no reordering: each atomic name is wrapped in `\\mathrm{...}`, `*` becomes `{\\cdot}`, `/` stays, `^N` becomes `^{N}`, and `sqrt(X)` becomes `\\sqrt{...}` (recursing on the inner expression).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.553963Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.553901Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.555567Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.555381Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "for s in [\"eV/c\", \"kg*m/s\", \"m^2\", \"s^-1\", \"m^(1/2)\", \"sqrt(m)\", \"sqrt(kg*m)\"]:\n",
+    "    print(f\"{s:>12}  ->  {pmd_unit(s).to_tex()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because the translation is structural, `to_tex()` reflects the *stored* symbol — not the simplified form. A redundant compound stays compound:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.556517Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.556452Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.558186Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.558001Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "u = pmd_unit(\"m*s/m\")  # dimension reduces, but the stored symbol is preserved\n",
+    "u.unitSymbol, u.to_tex(), u.simplify().unitSymbol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`beamphysics.labels.mathlabel` consumes this when building axis labels, so any quantity with a `pmd_unit` will render correctly as a mathtext string:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.559094Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.559032Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.561095Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.560912Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from beamphysics.labels import mathlabel\n",
+    "\n",
+    "mathlabel(\"x_bar\", units=sqrt_unit(pmd_unit(\"m\")))"
    ]
   },
   {
@@ -523,6 +1095,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T04:26:07.562048Z",
+     "iopub.status.busy": "2026-06-09T04:26:07.561988Z",
+     "iopub.status.idle": "2026-06-09T04:26:07.563545Z",
+     "shell.execute_reply": "2026-06-09T04:26:07.563296Z"
+    },
     "tags": []
    },
    "outputs": [],

--- a/docs/examples/units.ipynb
+++ b/docs/examples/units.ipynb
@@ -14,10 +14,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.261363Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.261163Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.425497Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.425206Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.503076Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.502992Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.745459Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.745206Z"
     },
     "tags": []
    },
@@ -27,7 +27,6 @@
     "    NAMED_UNITS,\n",
     "    dimension_name,\n",
     "    pmd_unit,\n",
-    "    power_unit,\n",
     "    sqrt_unit,\n",
     ")\n",
     "from beamphysics import particle_paths\n",
@@ -46,10 +45,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.426880Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.426758Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.429772Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.429506Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.746877Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.746749Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.749800Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.749595Z"
     },
     "tags": []
    },
@@ -62,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get a known units. These can be multiplied and divided:"
+    "Named units can be multiplied, divided, and raised to a power (`*`, `/`, `**`):"
    ]
   },
   {
@@ -70,10 +69,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.448148Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.448021Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.450898Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.450664Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.766954Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.766847Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.769543Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.769330Z"
     },
     "tags": []
    },
@@ -81,63 +80,7 @@
    "source": [
     "u1 = pmd_unit(\"J\")\n",
     "u2 = pmd_unit(\"m\")\n",
-    "u1, u2, u1 / u2, u1 * u2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.451887Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.451801Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.453715Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.453508Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pmd_unit(\"W/sqrt(Hz)\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.454743Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.454670Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.456591Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.456367Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "(pmd_unit(\"W/sqrt(m)\") * pmd_unit(\"sqrt(m)\")).simplify()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Special function for `sqrt`. It halves the dimension exponents, so the result can carry fractional dimensions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.457635Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.457565Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.459337Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.459130Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "sqrt_unit(u1)"
+    "u1 * u2, u1 / u2, u1**2"
    ]
   },
   {
@@ -146,14 +89,7 @@
    "source": [
     "## Power notation\n",
     "\n",
-    "Units can be raised to powers using `^` notation. Integer, decimal, and fractional powers are supported:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Integer and decimal powers:"
+    "`^` accepts any rational exponent — integer, decimal, parenthesised fraction, or the equivalent `sqrt(...)` form. Fractional exponents are carried in the dimension tuple:"
    ]
   },
   {
@@ -161,22 +97,23 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.460346Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.460281Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.462089Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.461852Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.770703Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.770601Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.772581Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.772375Z"
     }
    },
    "outputs": [],
    "source": [
-    "pmd_unit(\"m^2\"), pmd_unit(\"m^-1\"), pmd_unit(\"m^0.5\")"
+    "# All four spellings parse; the last two are equivalent.\n",
+    "{s: pmd_unit(s) for s in [\"m^2\", \"m^-1\", \"m^(3/2)\", \"sqrt(m)\", \"m^(1/2)\"]}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fractional powers using parentheses, e.g. `m^(-3/2)`, `m^(1/2)`:"
+    "The `**` operator (or `power_unit(u, n)`) raises a unit to a power. For compound symbols the exponent is distributed across each token, so `(eV*s) ** 2` yields `eV^2*s^2` — not `eV*s^2`, which the flat parser would read as `eV*(s^2)`:"
    ]
   },
   {
@@ -184,131 +121,15 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.463205Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.463136Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.464897Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.464715Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.773602Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.773528Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.775530Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.775251Z"
     }
    },
    "outputs": [],
    "source": [
-    "pmd_unit(\"m^(-3/2)\"), pmd_unit(\"m^(3/2)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`sqrt()` notation is equivalent to `^(1/2)`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.465842Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.465780Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.467444Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.467267Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pmd_unit(\"sqrt(m)\"), pmd_unit(\"m^(1/2)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Powers work in compound expressions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.468373Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.468298Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.469793Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.469623Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pmd_unit(\"eV/c*m^(-1/2)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Fractional dimensions are preserved:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.470759Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.470685Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.472547Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.472364Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "u = pmd_unit(\"m^(-3/2)\")\n",
-    "u.unitDimension  # Length dimension is -1.5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`power_unit(u, n)` raises a unit to an arbitrary power. For a compound symbol, the exponent is distributed across each token — so `(eV*s)^2` produces `eV^2*s^2`, with the dimension multiplied through correctly (and not the malformed `eV*s^2`, which the flat left-associative parser would read as `eV*(s^2)`):\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.473506Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.473443Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.475164Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.474969Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "power_unit(pmd_unit(\"eV*s\"), 2), power_unit(pmd_unit(\"m^2*s^-1\"), 3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "accepts `*` and `/`  between two known symbols."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.476116Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.476055Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.477535Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.477347Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pmd_unit(\"W*s\")"
+    "pmd_unit(\"eV*s\") ** 2, pmd_unit(\"m^2*s^-1\") ** 3"
    ]
   },
   {
@@ -324,10 +145,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.478499Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.478432Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.480289Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.480059Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.776657Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.776585Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.778592Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.778383Z"
     }
    },
    "outputs": [],
@@ -347,23 +168,16 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.481357Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.481287Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.483231Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.483028Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.779592Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.779519Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.781390Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.781185Z"
     }
    },
    "outputs": [],
    "source": [
     "pmd_unit(\"Ohm\"), pmd_unit(\"Ω\"), pmd_unit(\"deg\"), pmd_unit(\"degree\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -379,10 +193,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.484247Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.484184Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.485965Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.485766Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.782347Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.782284Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.784003Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.783791Z"
     }
    },
    "outputs": [],
@@ -402,10 +216,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.486918Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.486856Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.488536Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.488326Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.784951Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.784888Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.786592Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.786401Z"
     }
    },
    "outputs": [],
@@ -425,10 +239,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.489530Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.489471Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.491110Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.490909Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.787560Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.787484Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.789133Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.788942Z"
     }
    },
    "outputs": [],
@@ -448,10 +262,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.492047Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.491981Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.493614Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.493426Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.790041Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.789979Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.791631Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.791432Z"
     }
    },
    "outputs": [],
@@ -483,10 +297,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.494541Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.494480Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.496250Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.496043Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.792758Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.792674Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.794625Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.794413Z"
     }
    },
    "outputs": [],
@@ -507,10 +321,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.497197Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.497135Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.499142Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.498949Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.795668Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.795605Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.797624Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.797421Z"
     }
    },
    "outputs": [],
@@ -518,7 +332,7 @@
     "(\n",
     "    (pmd_unit(\"V\") * pmd_unit(\"A\")).simplify(),  # -> W\n",
     "    (pmd_unit(\"J\") / pmd_unit(\"C\")).simplify(),  # -> V\n",
-    "    (pmd_unit(\"T\") * pmd_unit(\"m\")).simplify(),  # -> T*m (no single name)\n",
+    "    (pmd_unit(\"T\") * pmd_unit(\"m\")).simplify(),  # -> T*m\n",
     ")"
    ]
   },
@@ -527,10 +341,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.500018Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.499958Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.501735Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.501561Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.798567Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.798506Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.800332Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.800132Z"
     }
    },
    "outputs": [],
@@ -554,10 +368,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.502602Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.502542Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.504121Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.503936Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.801267Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.801207Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.802868Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.802673Z"
     }
    },
    "outputs": [],
@@ -579,10 +393,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.505092Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.505020Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.506775Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.506597Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.803811Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.803745Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.805536Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.805344Z"
     }
    },
    "outputs": [],
@@ -596,10 +410,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.507653Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.507592Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.509361Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.509197Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.806503Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.806444Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.808268Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.808077Z"
     }
    },
    "outputs": [],
@@ -620,10 +434,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.510277Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.510217Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.511886Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.511694Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.809273Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.809207Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.810988Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.810794Z"
     }
    },
    "outputs": [],
@@ -643,10 +457,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.512997Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.512923Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.514632Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.514442Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.811936Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.811874Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.813453Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.813272Z"
     }
    },
    "outputs": [],
@@ -670,10 +484,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.515546Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.515481Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.516945Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.516766Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.814408Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.814352Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.815739Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.815553Z"
     }
    },
    "outputs": [],
@@ -700,10 +514,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.517855Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.517796Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.519514Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.519336Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.816691Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.816615Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.818344Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.818158Z"
     }
    },
    "outputs": [],
@@ -723,10 +537,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.520510Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.520451Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.522156Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.521961Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.819250Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.819189Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.820960Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.820773Z"
     }
    },
    "outputs": [],
@@ -747,10 +561,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.523056Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.522994Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.524507Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.524340Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.821863Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.821804Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.823383Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.823187Z"
     }
    },
    "outputs": [],
@@ -770,15 +584,64 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.525478Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.525405Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.527107Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.526942Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.824381Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.824316Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.826214Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.825979Z"
     }
    },
    "outputs": [],
    "source": [
     "hash(pmd_unit(\"1/s\")) == hash(pmd_unit(\"Hz\")), len({pmd_unit(\"1/s\"), pmd_unit(\"Hz\")})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dimension compatibility and conversion factors\n",
+    "\n",
+    "`compatible_with` is a pure-dimension check (SI scale ignored). `conversion_factor_to` returns the multiplicative SI factor between two compatible units, and raises `ValueError` if the dimensions don't match:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T18:16:18.827209Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.827132Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.829030Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.828843Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    pmd_unit(\"eV\").compatible_with(pmd_unit(\"J\")),  # True (energy)\n",
+    "    pmd_unit(\"m\").compatible_with(pmd_unit(\"s\")),  # False (length vs time)\n",
+    "    pmd_unit(\"eV\").conversion_factor_to(pmd_unit(\"J\")),  # e_charge\n",
+    "    pmd_unit(\"km\").conversion_factor_to(pmd_unit(\"m\")),  # 1000.0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T18:16:18.829959Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.829899Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.831466Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.831283Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    pmd_unit(\"m\").conversion_factor_to(pmd_unit(\"s\"))\n",
+    "except ValueError as ex:\n",
+    "    print(f\"ValueError: {ex}\")"
    ]
   },
   {
@@ -795,10 +658,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.528012Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.527953Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.530334Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.530152Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.832386Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.832325Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.835036Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.834860Z"
     },
     "tags": []
    },
@@ -826,10 +689,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.531267Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.531205Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.532954Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.532748Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.835907Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.835849Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.837624Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.837407Z"
     }
    },
    "outputs": [],
@@ -850,10 +713,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.533836Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.533777Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.535969Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.535776Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.838523Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.838462Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.840945Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.840746Z"
     },
     "tags": []
    },
@@ -868,10 +731,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.536898Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.536837Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.538475Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.538296Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.841857Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.841799Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.843495Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.843296Z"
     },
     "tags": []
    },
@@ -892,10 +755,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.539380Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.539309Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.540869Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.540705Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.844444Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.844370Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.846004Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.845817Z"
     },
     "tags": []
    },
@@ -916,10 +779,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.541798Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.541738Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.543036Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.542839Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.846954Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.846893Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.848169Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.847994Z"
     },
     "tags": []
    },
@@ -940,10 +803,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.543916Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.543857Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.545473Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.545282Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.849083Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.849026Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.850702Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.850516Z"
     },
     "tags": []
    },
@@ -959,10 +822,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.546536Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.546450Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.548377Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.548201Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.851583Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.851511Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.853250Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.853070Z"
     },
     "tags": []
    },
@@ -976,10 +839,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.549291Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.549231Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.550578Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.550409Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.854143Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.854083Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.855343Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.855160Z"
     },
     "tags": []
    },
@@ -993,10 +856,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.551475Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.551416Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.553022Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.552836Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.856274Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.856216Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.857808Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.857616Z"
     },
     "tags": []
    },
@@ -1019,10 +882,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.553963Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.553901Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.555567Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.555381Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.858725Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.858654Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.860459Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.860230Z"
     }
    },
    "outputs": [],
@@ -1043,10 +906,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.556517Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.556452Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.558186Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.558001Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.861487Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.861417Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.863288Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.863091Z"
     }
    },
    "outputs": [],
@@ -1067,10 +930,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.559094Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.559032Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.561095Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.560912Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.864226Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.864166Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.866322Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.866154Z"
     }
    },
    "outputs": [],
@@ -1096,10 +959,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T04:26:07.562048Z",
-     "iopub.status.busy": "2026-06-09T04:26:07.561988Z",
-     "iopub.status.idle": "2026-06-09T04:26:07.563545Z",
-     "shell.execute_reply": "2026-06-09T04:26:07.563296Z"
+     "iopub.execute_input": "2026-06-09T18:16:18.867234Z",
+     "iopub.status.busy": "2026-06-09T18:16:18.867176Z",
+     "iopub.status.idle": "2026-06-09T18:16:18.868672Z",
+     "shell.execute_reply": "2026-06-09T18:16:18.868481Z"
     },
     "tags": []
    },

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov
   - pyyaml
+  - pint  # test-only: independent oracle for beamphysics.units
   - jupyterlab>=3
   - nbconvert
   # Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "pytest-benchmark", "pyyaml"]
+dev = ["pytest", "pytest-cov", "pytest-benchmark", "pyyaml", "pint"]
 doc = [
   "mkdocs",
   "mkdocs-jupyter",

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from beamphysics.labels import mathlabel
+from beamphysics.units import pmd_unit, sqrt_unit
+
+
+def test_mathlabel_renders_pmd_unit_via_to_tex() -> None:
+    assert mathlabel("x", units=pmd_unit("eV/c")) == r"$x~(\mathrm{eV}/\mathrm{c})$"
+    assert (
+        mathlabel("x_bar", units=sqrt_unit(pmd_unit("m")))
+        == r"$\overline{x}~(\sqrt{\mathrm{m}})$"
+    )
+
+
+def test_mathlabel_parses_unit_strings() -> None:
+    # A str that parses as a unit symbol renders through to_tex.
+    assert mathlabel("x", units="kg*m/s") == (
+        r"$x~(\mathrm{kg}{\cdot}\mathrm{m}/\mathrm{s})$"
+    )
+
+
+def test_mathlabel_unparseable_string_fallback_keeps_cdot() -> None:
+    # Regression: the fallback for strings that are not valid unit symbols
+    # must still replace "*" with {\cdot} (as the pre-to_tex code did).
+    label = mathlabel("x", units="foo*bar")
+    assert r"{\cdot}" in label
+    assert "*" not in label
+
+
+def test_mathlabel_dimensionless_unit_adds_no_parens() -> None:
+    # Regression: a pmd_unit is always truthy, so the non-TeX branch used to
+    # emit "x ()" for a dimensionless unit (empty symbol). Both branches must
+    # omit the unit annotation entirely.
+    dimensionless = pmd_unit("1")
+    assert mathlabel("x", units=pmd_unit(""), tex=False) == "x"
+    assert mathlabel("x", units=pmd_unit(""), tex=True) == "$x$"
+    # pmd_unit("1") stores the symbol "1" and is annotated as such.
+    assert mathlabel("x", units=dimensionless, tex=False) == "x (1)"
+
+
+def test_mathlabel_no_units() -> None:
+    assert mathlabel("x", tex=False) == "x"
+    assert mathlabel("x", units=None, tex=True) == "$x$"
+    assert mathlabel("x", units="", tex=True) == "$x$"
+
+
+def test_mathlabel_non_tex_uses_symbol() -> None:
+    assert mathlabel("x", units=pmd_unit("eV/c"), tex=False) == "x (eV/c)"
+    assert mathlabel("x", "y", units="µC", tex=False) == "x, y (µC)"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -20,17 +20,16 @@ def test_mathlabel_parses_unit_strings() -> None:
 
 
 def test_mathlabel_unparseable_string_fallback_keeps_cdot() -> None:
-    # Regression: the fallback for strings that are not valid unit symbols
-    # must still replace "*" with {\cdot} (as the pre-to_tex code did).
+    # The fallback for strings that are not valid unit symbols still
+    # replaces "*" with {\cdot}.
     label = mathlabel("x", units="foo*bar")
     assert r"{\cdot}" in label
     assert "*" not in label
 
 
 def test_mathlabel_dimensionless_unit_adds_no_parens() -> None:
-    # Regression: a pmd_unit is always truthy, so the non-TeX branch used to
-    # emit "x ()" for a dimensionless unit (empty symbol). Both branches must
-    # omit the unit annotation entirely.
+    # A dimensionless unit (empty symbol) adds no "()" annotation in either
+    # branch. (A pmd_unit is always truthy, so the check must use its str.)
     dimensionless = pmd_unit("1")
     assert mathlabel("x", units=pmd_unit(""), tex=False) == "x"
     assert mathlabel("x", units=pmd_unit(""), tex=True) == "$x$"

--- a/tests/test_plot_labels.py
+++ b/tests/test_plot_labels.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+from beamphysics import single_particle
+from beamphysics.labels import mathlabel
+from beamphysics.plot import (
+    _charge_density_units_str,
+    marginal_plot,
+)
+from beamphysics.units import plottable_array_and_units, pmd_unit
+
+
+@pytest.mark.parametrize(
+    ("factor", "symbol", "expected"),
+    [
+        (1, "m", "m"),
+        (1e-3, "m", "mm"),
+        (1e-3, "eV/c", "meV/c"),  # spelling kept: prefix on the leading token
+        (1e6, "V/m", "MV/m"),
+        # Gluing would change the meaning -> explicit power of ten.
+        (1e-3, "m^2", "1e-3 m^2"),  # 'mm^2' would read as (mm)^2 = 1e-6
+        (1e-3, "sqrt(m)", "1e-3 sqrt(m)"),  # 'msqrt(m)' is unparseable
+        (1e-3, "1/m", "1e-3 1/m"),
+        # Re-spelling rescues cases the spelling can't express.
+        (1e-6, "mC", "nC"),  # never a double prefix
+        (1e3, "1/s", "kHz"),
+        (1e-3, "", "1e-3"),  # dimensionless: pure number
+        (2.0, "m", "2 m"),  # non-power-of-ten factor written plainly
+    ],
+)
+def test_scaled_symbol(factor: float, symbol: str, expected: str) -> None:
+    assert pmd_unit(symbol).scaled_symbol(factor) == expected
+
+
+def test_scaled_symbol_output_never_misparses() -> None:
+    """Whatever scaled_symbol returns either re-parses to the scaled unit or
+    is not a parseable unit symbol at all — never a different unit."""
+    for factor in (1e-3, 1e3, 1e-6, 1e9):
+        for symbol in ("m", "eV/c", "m^2", "sqrt(m)", "1/m", "T*m", "kg*m/s"):
+            base = pmd_unit(symbol)
+            out = base.scaled_symbol(factor)
+            try:
+                parsed = pmd_unit(out)
+            except (ValueError, KeyError):
+                continue  # explicit 1eN form: not a unit symbol, fine
+            assert parsed.compatible_with(base)
+            assert parsed.unitSI == pytest.approx(factor * base.unitSI)
+
+
+def test_scaled_symbol_finds_named_units() -> None:
+    # Exact named/prefixed match through simplify.
+    assert pmd_unit("C").scaled_symbol(1e-6) == "µC"
+    assert (pmd_unit("mA") * pmd_unit("s")).scaled_symbol(1e-6) == "nC"
+    assert pmd_unit("m").scaled_symbol(1) == "m"
+
+
+def test_charge_density_units_str() -> None:
+    """Histogram density labels keep the displayed axis unit (with its own
+    prefix) as the denominator, with the histogram prefix on the C. A time
+    axis instead displays in amps, with the two scales folded into one
+    prefix."""
+    s, m = pmd_unit("s"), pmd_unit("m")
+    # Time axes: C/s = A.
+    assert _charge_density_units_str(s, "s", 1.0) == "A"
+    assert _charge_density_units_str(s, "s", 1e-3) == "mA"
+    assert _charge_density_units_str(s, "µs", 1.0, 1e-6) == "MA"  # 1 C/µs
+    # Other axes: prefixed C per displayed axis unit.
+    assert _charge_density_units_str(m, "µm", 1e-9) == "nC/µm"
+    assert _charge_density_units_str(m, "m", 1.0) == "C/m"
+    assert _charge_density_units_str(pmd_unit("eV/c"), "keV/c", 1e-12) == "pC/(keV/c)"
+    # Unparseable axis units (explicit power-of-ten form) stay grouped.
+    assert (
+        _charge_density_units_str(pmd_unit("sqrt(m)"), "1e-3 sqrt(m)", 1e-9)
+        == "nC/(1e-3 sqrt(m))"
+    )
+
+
+def test_marginal_density_labels_keep_axis_prefixes() -> None:
+    """The marginal histogram labels read as charge per *displayed* axis
+    unit — nC/µm against an x axis in µm, pC/(keV/c) against keV/c — rather
+    than consolidating everything into one prefix against the SI unit. A
+    time axis is the exception: C/s displays as amps."""
+    import matplotlib.pyplot as plt
+
+    from beamphysics import ParticleGroup
+
+    P = ParticleGroup("docs/examples/data/bmad_particles.h5")
+
+    fig = marginal_plot(P, "x", "px")
+    xlabel = fig.axes[0].get_xlabel()
+    x_marg = fig.axes[1].get_ylabel()
+    y_marg = fig.axes[2].get_xlabel()
+    # The denominator of each marginal label is the axis unit as displayed.
+    assert r"\mathrm{µm}" in xlabel
+    assert x_marg.endswith(r"/\mathrm{µm}$")
+    assert y_marg.endswith(r"/(\mathrm{keV}/\mathrm{c})$")
+    plt.close("all")
+
+    fig = marginal_plot(P, "t", "p")
+    assert fig.axes[1].get_ylabel().endswith(r"\mathrm{A}$")
+    plt.close("all")
+
+
+def test_plottable_array_and_units_tolerates_unparseable_strings() -> None:
+    """User-supplied unit strings that are not unit symbols still get a
+    correct power-of-ten label instead of raising."""
+    import numpy as np
+
+    arr = np.array([1e3, 2e3])
+    _, _, units_str, _, _ = plottable_array_and_units(arr, "counts")
+    assert units_str == "1e3 counts"
+    _, _, units_str, _, _ = plottable_array_and_units(arr, "counts", nice=False)
+    assert units_str == "counts"
+
+
+def test_mathlabel_units_only() -> None:
+    """mathlabel with no keys is a units-only label, as used by the
+    marginal histograms."""
+    assert mathlabel(units="") == ""
+    assert mathlabel(units="A") == r"$\mathrm{A}$"
+    assert mathlabel(units="C/(eV/c)") == r"$\mathrm{C}/(\mathrm{eV}/\mathrm{c})$"
+    # Unparseable falls back to mathrm with * -> cdot.
+    assert r"{\cdot}" in mathlabel(units="foo*bar")
+    assert mathlabel(units="eV/c", tex=False) == "eV/c"
+
+
+def test_single_particle_plots_draw() -> None:
+    """Plots for a single particle (dimensionless densities, degenerate
+    histograms) must render without mathtext errors."""
+    import matplotlib.pyplot as plt
+
+    P = single_particle(pz=10e6)
+    for key in ("weight", "x", "p"):
+        P.plot("z", key)
+        plt.gcf().canvas.draw()  # force label rendering
+        plt.close("all")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -22,16 +22,28 @@ def test_deprecated_unit():
         assert deprecated_unit("T") == pmd_unit("T")
 
 
+def assert_round_trip(u: pmd_unit) -> None:
+    """Re-parsing the unit's symbol must reproduce its dimension and SI value.
+
+    Parse / dimension / SI failures all surface as pytest errors with the
+    offending symbol in the message — no try/except swallowing them.
+    """
+    reparsed = pmd_unit(u.unitSymbol)
+    assert (
+        reparsed.unitDimension == u.unitDimension
+    ), f"{u.unitSymbol!r}: dimension {reparsed.unitDimension} != {u.unitDimension}"
+    assert reparsed.unitSI == u.unitSI or math.isclose(
+        reparsed.unitSI, u.unitSI, rel_tol=1e-9
+    ), f"{u.unitSymbol!r}: SI {reparsed.unitSI} != {u.unitSI}"
+
+
 def _round_trips(u: pmd_unit) -> bool:
-    """A unit round-trips if re-parsing its symbol reproduces it."""
+    """Bool predicate wrapping ``assert_round_trip`` for use as a test guard."""
     try:
-        reparsed = pmd_unit(u.unitSymbol)
-    except (ValueError, KeyError):
+        assert_round_trip(u)
+    except (AssertionError, ValueError, KeyError):
         return False
-    return reparsed.unitDimension == u.unitDimension and (
-        reparsed.unitSI == u.unitSI
-        or math.isclose(reparsed.unitSI, u.unitSI, rel_tol=1e-9)
-    )
+    return True
 
 
 @pytest.mark.parametrize(
@@ -63,7 +75,7 @@ def test_simplify_division_by_compound_round_trips() -> None:
     # Regression: a compound divisor (e.g. "W") must not be emitted as a
     # bare "a/b/c" string that the flat, left-associative parser regroups.
     simplified = (pmd_unit("V/m") / pmd_unit("W")).simplify()
-    assert _round_trips(simplified)
+    assert_round_trip(simplified)
 
 
 @pytest.mark.parametrize("si", [1e-3, 1e3, 1e-6, 2.0])
@@ -91,9 +103,7 @@ def test_simplify_never_breaks_round_trip() -> None:
         for u in (a * b, a / b):
             if not _round_trips(u):
                 continue  # construction already mangled the symbol; not our concern
-            assert _round_trips(
-                u.simplify()
-            ), f"{u.unitSymbol} -> {u.simplify().unitSymbol}"
+            assert_round_trip(u.simplify())
 
 
 @pytest.mark.parametrize(
@@ -145,8 +155,7 @@ def test_simplify_prefixed_output_round_trips() -> None:
         pmd_unit("ratio_v", 1e3, dimension("electric_potential")),  # -> "kV"
         pmd_unit("ratio_m", 1e-6, dimension("mass")),  # -> "mg"
     ):
-        simplified = u.simplify()
-        assert _round_trips(simplified), simplified.unitSymbol
+        assert_round_trip(u.simplify())
 
 
 def test_simplify_dimensionless_ratio_not_compound() -> None:
@@ -182,7 +191,7 @@ def test_ohm_unit_and_alias() -> None:
     ["V/C/m", "V/C", "Ohm/m", "Ω/m", "V/pC/m", "MV/m", "1/mm"],
 )
 def test_wakefield_unit_strings_parse(symbol: str) -> None:
-    assert _round_trips(pmd_unit(symbol))
+    assert_round_trip(pmd_unit(symbol))
 
 
 def test_sqrt_unit_halves_dimension() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -365,6 +365,49 @@ def test_multiply_same_symbol_round_trips() -> None:
     assert_round_trip(cubed)
 
 
+@pytest.mark.parametrize(
+    ("numerator", "divisor"),
+    [
+        ("V/m", "eV/c"),
+        ("V", "m*s"),
+        ("W", "m^2*s^-1"),
+        ("T", "kg*m/s"),
+        ("eV/c", "eV/c/s"),
+    ],
+)
+def test_divide_by_compound_divisor_round_trips(numerator: str, divisor: str) -> None:
+    """Regression: dividing by a compound unit must distribute the division
+    across the divisor's tokens (inverting its operators), because the flat,
+    left-associative parser regroups a naive ``"a/b/c"`` emission:
+    ``V/(eV/c)`` written as ``"V/eV/c"`` reads back as ``V/(eV*c)``.
+    """
+    assert_round_trip(pmd_unit(numerator) / pmd_unit(divisor))
+
+
+def test_divide_with_empty_numerator_symbol() -> None:
+    """The dimensionless identity (empty symbol) as numerator must emit
+    ``"1/..."``, not a malformed symbol starting with a bare operator."""
+    inv_m = pmd_unit("") / pmd_unit("m")
+    assert inv_m.unitSymbol == "1/m"
+    assert_round_trip(inv_m)
+
+
+def test_unicode_homoglyphs_normalized() -> None:
+    """U+2126 OHM SIGN folds (via NFC) into U+03A9 GREEK CAPITAL OMEGA -- the
+    codepoint NAMED_UNITS uses -- and GREEK SMALL MU (U+03BC) is translated to
+    MICRO SIGN (U+00B5), which SHORT_PREFIX_FACTOR keys on. Users pasting
+    either variant get the same unit. Explicit escapes are used here because
+    the variants are visually indistinguishable in source.
+    """
+    assert pmd_unit("\u2126") == pmd_unit("\u03a9")  # OHM SIGN == GREEK OMEGA
+    assert pmd_unit("\u2126").unitSymbol == "\u03a9"
+    assert math.isclose(pmd_unit("k\u2126").unitSI, 1e3)
+    assert pmd_unit("\u03bcm") == pmd_unit("\u00b5m")  # Greek mu == micro sign
+    assert pmd_unit("\u03bcm").unitSymbol == "\u00b5m"
+    assert math.isclose(pmd_unit("\u03bcm").unitSI, 1e-6)
+    assert math.isclose(pmd_unit("\u03bcrad").unitSI, 1e-6)
+
+
 def test_negative_power_normalizes_negative_zero() -> None:
     """Negative exponents must not produce ``-0.0`` in the dimension tuple.
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -81,7 +81,7 @@ def test_simplify_division_by_compound_round_trips() -> None:
 @pytest.mark.parametrize("si", [1e-3, 1e3, 1e-6, 2.0])
 def test_simplify_dimensionless_never_bare_prefix(si: float) -> None:
     # Regression: an SI prefix on a dimensionless unit produced bogus symbols
-    # like "m" (re-parses as metres) or "k" (unparseable). The result must
+    # like "m" (re-parses as meters) or "k" (unparseable). The result must
     # stay dimensionless and never be a bare SI prefix.
     result = pmd_unit("ratio", si, (0, 0, 0, 0, 0, 0, 0)).simplify()
     assert result.unitDimension == (0, 0, 0, 0, 0, 0, 0)
@@ -265,6 +265,19 @@ def test_equality_is_value_based_per_standard() -> None:
     assert pmd_unit("eV") != pmd_unit("J")  # same dim, different unitSI
     # Hash invariant: equal objects must share a hash.
     assert hash(pmd_unit("1/s")) == hash(pmd_unit("Hz"))
+
+
+def test_hash_distinguishes_same_dimension_units() -> None:
+    """__hash__ keys on (dimension, canonical unitSI), not dimension alone, so
+    distinct same-dimension scales land in distinct buckets instead of all
+    colliding. The hash/eq invariant (equal -> same hash) is preserved."""
+    energy = [pmd_unit("eV"), pmd_unit("J"), pmd_unit("keV"), pmd_unit("MeV")]
+    # All share the energy dimension but are pairwise unequal (different SI).
+    assert len({hash(u) for u in energy}) == len(energy)
+    # Invariant still holds for an arithmetic-drifted equal pair.
+    rebuilt = pmd_unit("eV/c") * pmd_unit("c")
+    assert rebuilt == pmd_unit("eV")
+    assert hash(rebuilt) == hash(pmd_unit("eV"))
 
 
 def test_hashability() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -266,9 +266,10 @@ def test_equality_is_value_based_per_standard() -> None:
 
 
 def test_hash_distinguishes_same_dimension_units() -> None:
-    """__hash__ keys on (dimension, canonical unitSI), not dimension alone, so
-    distinct same-dimension scales land in distinct buckets instead of all
-    colliding. The hash/eq invariant (equal -> same hash) is preserved."""
+    """The hash includes the rounded unitSI, not just the dimension, so
+    units that share a dimension but differ in scale (eV, keV, J) get
+    different hashes instead of all colliding in one bucket. Equal units
+    still hash equal."""
     energy = [pmd_unit("eV"), pmd_unit("J"), pmd_unit("keV"), pmd_unit("MeV")]
     # All share the energy dimension but are pairwise unequal (different SI).
     assert len({hash(u) for u in energy}) == len(energy)
@@ -431,11 +432,12 @@ def test_divide_with_empty_numerator_symbol() -> None:
 
 
 def test_unicode_homoglyphs_normalized() -> None:
-    """U+2126 OHM SIGN folds (via NFC) into U+03A9 GREEK CAPITAL OMEGA -- the
-    codepoint NAMED_UNITS uses -- and GREEK SMALL MU (U+03BC) is translated to
-    MICRO SIGN (U+00B5), which SHORT_PREFIX_FACTOR keys on. Users pasting
-    either variant get the same unit. Explicit escapes are used here because
-    the variants are visually indistinguishable in source.
+    """A pasted Ω or µ must parse no matter which of its visually identical
+    Unicode twins it is: OHM SIGN (U+2126) is converted to GREEK CAPITAL
+    OMEGA (U+03A9, the character in NAMED_UNITS), and GREEK SMALL MU
+    (U+03BC) to MICRO SIGN (U+00B5, the character in SHORT_PREFIX_FACTOR).
+    Explicit escapes are used here because the twins look the same in
+    source code.
     """
     assert pmd_unit("\u2126") == pmd_unit("\u03a9")  # OHM SIGN == GREEK OMEGA
     assert pmd_unit("\u2126").unitSymbol == "\u03a9"
@@ -639,8 +641,8 @@ def test_to_tex_translation(symbol: str, expected_tex: str) -> None:
     simplification, no reordering.
     """
     if symbol in ("", "1"):
-        # These can't be round-tripped through pmd_unit() with unitSI=0 (the
-        # empty/identity sentinel), so construct directly.
+        # pmd_unit("") and pmd_unit("1") with the default unitSI=0 would go
+        # through symbol lookup; construct directly to control the symbol.
         u = pmd_unit(symbol, unitSI=1, unitDimension="1")
     else:
         u = pmd_unit(symbol)
@@ -733,3 +735,98 @@ def test_plottable_array_smoke(value: float | list[float]) -> None:
     ]:
         res, *_ = plottable_array(value, lim=lim, nice=nice)
         np.testing.assert_allclose(actual=res, desired=value)
+
+
+def test_named_units_are_float_typed() -> None:
+    """Every construction path yields float dimension tuples and a float
+    unitSI, per the openPMD standard (float64 attributes). The string-name
+    dimension path must coerce the same way the tuple path does."""
+    for u in NAMED_UNITS:
+        assert all(isinstance(d, float) for d in u.unitDimension), u
+        assert isinstance(u.unitSI, float), u
+    assert all(isinstance(d, float) for d in pmd_unit("T").unitDimension)
+    assert isinstance(pmd_unit("m").unitSI, float)
+
+
+def test_write_unit_h5_emits_float64_and_reads_back_bytes() -> None:
+    """write_unit_h5 writes float64 unitSI/unitDimension; read_unit_h5
+    decodes bytes unitSymbol attrs (as written by older fixed-length-string
+    writers) so unit arithmetic works on the result."""
+    h5py = pytest.importorskip("h5py")
+    import io
+
+    from beamphysics.units import read_unit_h5, write_unit_h5
+
+    bio = io.BytesIO()
+    with h5py.File(bio, "w") as f:
+        g = f.create_group("g")
+        write_unit_h5(g, pmd_unit("T"))
+        assert f["g"].attrs["unitDimension"].dtype == np.float64
+        assert isinstance(f["g"].attrs["unitSI"], float)
+
+        gb = f.create_group("gb")
+        gb.attrs["unitSI"] = 1.0
+        gb.attrs["unitDimension"] = (1, 0, 0, 0, 0, 0, 0)
+        gb.attrs["unitSymbol"] = np.bytes_("m")  # legacy bytes encoding
+        u = read_unit_h5(gb)
+        assert u.unitSymbol == "m"
+        assert (u * pmd_unit("s")).unitSymbol == "m*s"  # arithmetic works
+
+
+def test_sqrt_product_parses() -> None:
+    """The whole-string sqrt() match must not swallow a product of sqrts:
+    the final ')' of 'sqrt(m)*sqrt(m)' is not the partner of the first '('."""
+    u = pmd_unit("sqrt(m)*sqrt(m)")
+    assert u.unitDimension == (1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    assert u.simplify().unitSymbol == "m"
+    assert_round_trip(u)
+    # Nested sqrt still parses.
+    assert pmd_unit("sqrt(sqrt(m))").unitDimension == (0.25, 0, 0, 0, 0, 0, 0)
+
+
+def test_slice_statistic_keys_have_units() -> None:
+    """The keys slice_statistics emits ('current', 'density') resolve."""
+    assert pg_units("current") == pmd_unit("A")
+    assert pg_units("density") == pmd_unit("C") / pmd_unit("m")
+
+
+def test_nice_scale_prefix_returns_python_float() -> None:
+    """No numpy scalar leakage in the public API."""
+    f, p = nice_scale_prefix(2e-10)
+    assert type(f) is float and (f, p) == (1e-12, "p")
+    f, p = nice_scale_prefix(0)
+    assert type(f) is float and p == ""
+
+
+def test_units_module_doctests() -> None:
+    """Keep the docstring examples in beamphysics.units honest."""
+    import doctest
+
+    import beamphysics.units as units_module
+
+    results = doctest.testmod(units_module)
+    assert results.failed == 0, f"{results.failed} doctest failure(s)"
+
+
+def test_sqrt_of_compound_inside_expression() -> None:
+    """All notation must work uniformly at any recursion depth: the parser
+    has a single recursive entry point (from_symbol), so a sqrt-of-compound
+    token behaves the same alone and inside a larger expression."""
+    alone = pmd_unit("sqrt(kg*m)")
+    for s in ("sqrt(kg*m)*s", "s*sqrt(kg*m)", "V/sqrt(kg*m)", "sqrt(kg*m)^2"):
+        u = pmd_unit(s)
+        assert_round_trip(u)
+    assert pmd_unit("sqrt(kg*m)*s").unitDimension == tuple(
+        a + b for a, b in zip(alone.unitDimension, pmd_unit("s").unitDimension)
+    )
+    assert pmd_unit("sqrt(kg*m)^2") == pmd_unit("kg*m")
+
+
+def test_single_token_spelling_preserved() -> None:
+    """A lone token keeps the user's spelling as the stored symbol; the
+    parsed value is canonical regardless."""
+    assert pmd_unit("m^(1/2)").unitSymbol == "m^(1/2)"
+    assert pmd_unit("(eV/c)^2").unitSymbol == "(eV/c)^2"
+    assert pmd_unit("(eV/c)").unitSymbol == "(eV/c)"
+    assert pmd_unit("(m)").unitSymbol == "m"  # redundant parens drop
+    assert pmd_unit("m^(1/2)") == pmd_unit("m^0.5")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -72,17 +72,17 @@ def test_simplify_electric_potential_volt() -> None:
 
 
 def test_simplify_division_by_compound_round_trips() -> None:
-    # Regression: a compound divisor (e.g. "W") must not be emitted as a
-    # bare "a/b/c" string that the flat, left-associative parser regroups.
+    # simplify() output must re-parse to the same unit, including when the
+    # input was built by dividing by a compound unit.
     simplified = (pmd_unit("V/m") / pmd_unit("W")).simplify()
     assert_round_trip(simplified)
 
 
 @pytest.mark.parametrize("si", [1e-3, 1e3, 1e-6, 2.0])
 def test_simplify_dimensionless_never_bare_prefix(si: float) -> None:
-    # Regression: an SI prefix on a dimensionless unit produced bogus symbols
-    # like "m" (re-parses as meters) or "k" (unparseable). The result must
-    # stay dimensionless and never be a bare SI prefix.
+    # A simplified dimensionless unit must stay dimensionless and must never
+    # be a bare SI prefix (which would be unparseable, or collide with a
+    # named unit like "m").
     result = pmd_unit("ratio", si, (0, 0, 0, 0, 0, 0, 0)).simplify()
     assert result.unitDimension == (0, 0, 0, 0, 0, 0, 0)
     assert result.unitSymbol not in SHORT_PREFIX_FACTOR
@@ -159,9 +159,8 @@ def test_simplify_prefixed_output_round_trips() -> None:
 
 
 def test_simplify_dimensionless_ratio_not_compound() -> None:
-    # Regression: a pure-number ratio must not be "simplified" into a same-
-    # dimension compound like "kg/g" (mass/mass == 1000). It has no meaningful
-    # named form, so simplify returns it unchanged.
+    # A pure-number ratio has no meaningful named form: simplify must return
+    # it unchanged, never a same-dimension compound like "kg/g" (== 1000).
     u = pmd_unit("mrad/µrad")  # 1000, dimensionless
     s = u.simplify()
     assert s.unitDimension == (0, 0, 0, 0, 0, 0, 0)
@@ -195,8 +194,7 @@ def test_wakefield_unit_strings_parse(symbol: str) -> None:
 
 
 def test_sqrt_unit_halves_dimension() -> None:
-    # Regression: sqrt_unit used integer floor division (x // 2), so sqrt(m)
-    # collapsed to dimensionless instead of m^0.5.
+    # sqrt(m) has dimension m^0.5, carried as a fractional exponent.
     from beamphysics.units import sqrt_unit
 
     root_m = sqrt_unit(pmd_unit("m"))
@@ -217,8 +215,9 @@ def test_norm_emit_4d_stored_as_m_squared() -> None:
 
 
 def test_cov_units_with_prefixed_subkey() -> None:
-    # Regression: pg_units used key.strip("cov_"), which strips the char set
-    # {c,o,v,_} and mangled subkeys like "charge" -> "harge" (KeyError).
+    # The "cov_" prefix must be removed exactly (removeprefix, not
+    # strip("cov_"), which strips the char set {c,o,v,_} and would mangle
+    # subkeys like "charge").
     u = pg_units("cov_charge__x")
     assert u.unitDimension == (1, 0, 1, 1, 0, 0, 0)  # charge * length
     # Order independence and the common case still work.
@@ -227,9 +226,8 @@ def test_cov_units_with_prefixed_subkey() -> None:
 
 
 def test_parsing_compound_does_not_mutate_named_units() -> None:
-    # Regression: parsing a compound whose first token is a known unit used to
-    # mutate the shared NAMED_UNITS entry in place (e.g. parsing "m*rad" rewrote
-    # the global "m" symbol to "m*rad"), corrupting all later simplify() calls.
+    # Parsing must be side-effect-free: the shared NAMED_UNITS entries stay
+    # untouched no matter what symbols are parsed.
     before = [(u.unitSymbol, u.unitSI, u.unitDimension) for u in NAMED_UNITS]
     for symbol in ("m*rad", "rad*s", "rad*eV", "m/rad", "T*m", "kg*m/s"):
         pmd_unit(symbol)
@@ -351,11 +349,7 @@ def test_multiply() -> None:
 
 
 def test_multiply_same_symbol_round_trips() -> None:
-    """``m * m`` (and longer chains) must produce a re-parseable symbol.
-
-    Previously the s1 == s2 branch emitted ``"(m)^2"``, which the parser
-    rejected because bare parentheses are not a supported grouping.
-    """
+    """``m * m`` (and longer chains) must produce a re-parseable symbol."""
     squared = pmd_unit("m") * pmd_unit("m")
     assert squared.unitDimension == (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     assert_round_trip(squared)
@@ -376,12 +370,56 @@ def test_multiply_same_symbol_round_trips() -> None:
     ],
 )
 def test_divide_by_compound_divisor_round_trips(numerator: str, divisor: str) -> None:
-    """Regression: dividing by a compound unit must distribute the division
-    across the divisor's tokens (inverting its operators), because the flat,
-    left-associative parser regroups a naive ``"a/b/c"`` emission:
-    ``V/(eV/c)`` written as ``"V/eV/c"`` reads back as ``V/(eV*c)``.
-    """
+    """Dividing by a compound unit parenthesizes the divisor, so the symbol
+    re-parses to the same unit (``"a/b/c"`` means ``(a/b)/c``, a different
+    grouping)."""
     assert_round_trip(pmd_unit(numerator) / pmd_unit(divisor))
+
+
+def test_parenthesized_grouping_parses() -> None:
+    """``(expr)`` groups: ``V/(eV/c)`` divides by the whole group, while
+    ``V/eV/c`` means ``(V/eV)/c``."""
+    u = pmd_unit("V/(eV/c)")
+    assert u == pmd_unit("V") / pmd_unit("eV/c")
+    assert u.unitSymbol == "V/(eV/c)"
+    assert_round_trip(u)
+    assert u != pmd_unit("V/eV/c")  # grouping matters
+
+    # Nested groups.
+    nested = pmd_unit("W/(V/(eV/c))")
+    assert nested == pmd_unit("W") / (pmd_unit("V") / pmd_unit("eV/c"))
+    assert_round_trip(nested)
+
+    # Redundant parens around an atomic token are dropped.
+    assert pmd_unit("V/(m)").unitSymbol == "V/m"
+
+    # Whitespace inside a group canonicalizes.
+    assert pmd_unit("V / ( eV / c )").unitSymbol == "V/(eV/c)"
+
+
+def test_parenthesized_group_with_power() -> None:
+    """A group can carry an exponent: ``(eV*s)^2`` is ``(eV*s)`` squared,
+    not ``eV*(s^2)``. Fractional exponents work through the same branch."""
+    assert pmd_unit("(eV*s)^2") == pmd_unit("eV*s") ** 2
+    assert_round_trip(pmd_unit("(eV*s)^2"))
+    assert pmd_unit("(eV/c)^2") == pmd_unit("eV/c") ** 2
+    assert pmd_unit("(m^2*s^2)^(1/2)") == pmd_unit("m*s")
+    # power_unit distribution emits paren-power tokens that re-parse.
+    assert_round_trip(pmd_unit("V/(eV/c)") ** 2)
+
+
+@pytest.mark.parametrize("symbol", ["()", "V/()", "(m", "m)", "(a)(b)", "(m*)"])
+def test_malformed_parens_rejected(symbol: str) -> None:
+    with pytest.raises(ValueError):
+        pmd_unit(symbol)
+
+
+def test_divide_units_emits_parenthesized_divisor() -> None:
+    """Dividing by a compound unit wraps the divisor in parens — readable and
+    round-trips now that the parser understands grouping."""
+    u = pmd_unit("V/m") / pmd_unit("eV/c")
+    assert u.unitSymbol == "V/m/(eV/c)"
+    assert_round_trip(u)
 
 
 def test_divide_with_empty_numerator_symbol() -> None:
@@ -445,12 +483,9 @@ def test_legacy_multitoken_name_still_parses() -> None:
 
 
 def test_power_unit_distributes_over_compound() -> None:
-    """``power_unit`` must distribute the exponent across compound symbols.
-
-    Previously ``power_unit(pmd_unit("eV*s"), 2)`` emitted ``"eV*s^2"``,
-    which the flat left-associative parser reads as ``eV*(s^2)`` — the
-    wrong dimension (length-2,time-1,...) instead of (length-4,time-(-2),...).
-    """
+    """``power_unit`` distributes the exponent across compound symbols:
+    ``(eV*s)^2`` emits ``eV^2*s^2``, matching the dimension and round-tripping
+    through the parser."""
     from beamphysics.units import power_unit
 
     squared = power_unit(pmd_unit("eV*s"), 2)
@@ -508,12 +543,8 @@ def test_latex_sqrt_form_not_accepted() -> None:
 
 
 def test_simplify_skips_compound_numerator() -> None:
-    """``_best_compound_match`` must not propose a compound numerator.
-
-    A product ``compound*atomic`` parses correctly (left-associative), but
-    reads as ``compound`` divided by something to a human — confusing and
-    error-prone. Only ``atomic*atomic`` and ``atomic/atomic`` are emitted.
-    """
+    """``simplify`` emits only ``atomic*atomic`` and ``atomic/atomic``
+    compounds — a compound operand is not a simplification."""
     # Any simplify output must not be of the form "X/Y*Z" or "X*Y/Z" where
     # one of the operands is itself compound; the constraint we test is the
     # round-trip property (which would fail under ambiguous emission).
@@ -597,6 +628,8 @@ def test_negative_unitSI_rejected(bad_si: float) -> None:
         ("sqrt(m)", r"\sqrt{\mathrm{m}}"),
         ("sqrt(kg*m)", r"\sqrt{\mathrm{kg}{\cdot}\mathrm{m}}"),
         ("charge #", r"\mathrm{charge #}"),
+        ("V/(eV/c)", r"\mathrm{V}/(\mathrm{eV}/\mathrm{c})"),
+        ("(eV/c)^2", r"(\mathrm{eV}/\mathrm{c})^{2}"),
     ],
 )
 def test_to_tex_translation(symbol: str, expected_tex: str) -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 import numpy as np
 import pytest
+import itertools
+import math
+
 from beamphysics.units import (
+    NAMED_UNITS,
     SHORT_PREFIX_FACTOR,
     dimension,
     nice_array,
@@ -15,6 +19,91 @@ from beamphysics.units import (
 def test_deprecated_unit():
     with pytest.deprecated_call():
         assert deprecated_unit("T") == pmd_unit("T")
+
+
+def _round_trips(u: pmd_unit) -> bool:
+    """A unit round-trips if re-parsing its symbol reproduces it."""
+    try:
+        reparsed = pmd_unit(u.unitSymbol)
+    except (ValueError, KeyError):
+        return False
+    return reparsed.unitDimension == u.unitDimension and (
+        reparsed.unitSI == u.unitSI
+        or math.isclose(reparsed.unitSI, u.unitSI, rel_tol=1e-9)
+    )
+
+
+@pytest.mark.parametrize(
+    ("build", "expected_symbol"),
+    [
+        # Atomic matches (the float-tolerant path).
+        pytest.param(lambda: pmd_unit("eV/c") * pmd_unit("c"), "eV", id="eV/c*c->eV"),
+        pytest.param(lambda: pmd_unit("J") / pmd_unit("C"), "V", id="J/C->V"),
+        pytest.param(lambda: pmd_unit("V") * pmd_unit("A"), "W", id="V*A->W"),
+        # Compound matches.
+        pytest.param(lambda: pmd_unit("T") * pmd_unit("m"), "T*m", id="T*m"),
+        pytest.param(
+            lambda: pmd_unit("T") / pmd_unit("m") / pmd_unit("m") * pmd_unit("m"),
+            "T/m",
+            id="T/m",
+        ),
+    ],
+)
+def test_simplify_examples(build, expected_symbol: str) -> None:
+    assert build().simplify().unitSymbol == expected_symbol
+
+
+def test_simplify_electric_potential_volt() -> None:
+    # V = J/C = kg*m^2*s^-3*A^-1
+    assert pmd_unit("V").unitDimension == (2, 1, -3, -1, 0, 0, 0)
+
+
+def test_simplify_division_by_compound_round_trips() -> None:
+    # Regression: a compound divisor (e.g. "W") must not be emitted as a
+    # bare "a/b/c" string that the flat, left-associative parser regroups.
+    simplified = (pmd_unit("V/m") / pmd_unit("W")).simplify()
+    assert _round_trips(simplified)
+
+
+@pytest.mark.parametrize("si", [1e-3, 1e3, 1e-6, 2.0])
+def test_simplify_dimensionless_never_bare_prefix(si: float) -> None:
+    # Regression: an SI prefix on a dimensionless unit produced bogus symbols
+    # like "m" (re-parses as metres) or "k" (unparseable). The result must
+    # stay dimensionless and never be a bare SI prefix.
+    result = pmd_unit("ratio", si, (0, 0, 0, 0, 0, 0, 0)).simplify()
+    assert result.unitDimension == (0, 0, 0, 0, 0, 0, 0)
+    assert result.unitSymbol not in SHORT_PREFIX_FACTOR
+    try:
+        reparsed = pmd_unit(result.unitSymbol)
+    except (ValueError, KeyError):
+        # No simplification found: self returned with its placeholder symbol.
+        return
+    # If the symbol is parseable, it must not re-parse to a dimensioned unit.
+    assert reparsed.unitDimension == (0, 0, 0, 0, 0, 0, 0)
+
+
+def test_simplify_never_breaks_round_trip() -> None:
+    # Across every product/quotient of named units, simplify() must never
+    # turn a round-tripping unit into a non-round-tripping one.
+    named = [u for u in NAMED_UNITS if u.unitSymbol]
+    for a, b in itertools.product(named, named):
+        for u in (a * b, a / b):
+            if not _round_trips(u):
+                continue  # construction already mangled the symbol; not our concern
+            assert _round_trips(
+                u.simplify()
+            ), f"{u.unitSymbol} -> {u.simplify().unitSymbol}"
+
+
+def test_parsing_compound_does_not_mutate_named_units() -> None:
+    # Regression: parsing a compound whose first token is a known unit used to
+    # mutate the shared NAMED_UNITS entry in place (e.g. parsing "m*rad" rewrote
+    # the global "m" symbol to "m*rad"), corrupting all later simplify() calls.
+    before = [(u.unitSymbol, u.unitSI, u.unitDimension) for u in NAMED_UNITS]
+    for symbol in ("m*rad", "rad*s", "rad*eV", "m/rad", "T*m", "kg*m/s"):
+        pmd_unit(symbol)
+    after = [(u.unitSymbol, u.unitSI, u.unitDimension) for u in NAMED_UNITS]
+    assert before == after
 
 
 def test_smoke_properties() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -240,6 +240,23 @@ def test_equality() -> None:
     assert pmd_unit("T") != "foo"
 
 
+def test_equality_is_value_based_per_standard() -> None:
+    """Per the openPMD standard, a unit is defined by (unitSI, unitDimension);
+    the symbol is presentational. Two units denoting the same physical
+    quantity must therefore compare equal regardless of how they were
+    spelled, and survive floating-point drift introduced by arithmetic."""
+    # Cross-spelling equivalence — same SI and dimension via different syntax.
+    assert pmd_unit("1/s") == pmd_unit("Hz")
+    assert pmd_unit("s^-1") == pmd_unit("Hz")
+    # Arithmetic round-trip: (eV/c) * c must equal eV even though the
+    # intermediate float math doesn't reproduce e_charge bit-exactly.
+    assert pmd_unit("eV/c") * pmd_unit("c") == pmd_unit("eV")
+    # Different physical scale must remain unequal.
+    assert pmd_unit("eV") != pmd_unit("J")  # same dim, different unitSI
+    # Hash invariant: equal objects must share a hash.
+    assert hash(pmd_unit("1/s")) == hash(pmd_unit("Hz"))
+
+
 def test_hashability() -> None:
     assert len({pmd_unit("T"), pmd_unit("eV"), pmd_unit("T")}) == 2
 
@@ -304,6 +321,184 @@ def test_legacy_multitoken_name_still_parses() -> None:
     u = pmd_unit("charge #")
     assert u.unitDimension == dimension("charge")
     assert u.unitSI == 1
+
+
+def test_power_unit_distributes_over_compound() -> None:
+    """``power_unit`` must distribute the exponent across compound symbols.
+
+    Previously ``power_unit(pmd_unit("eV*s"), 2)`` emitted ``"eV*s^2"``,
+    which the flat left-associative parser reads as ``eV*(s^2)`` — the
+    wrong dimension (length-2,time-1,...) instead of (length-4,time-(-2),...).
+    """
+    from beamphysics.units import power_unit
+
+    squared = power_unit(pmd_unit("eV*s"), 2)
+    assert squared.unitDimension == (4.0, 2.0, -2.0, 0.0, 0.0, 0.0, 0.0)
+    assert_round_trip(squared)
+
+    # Existing exponents inside the compound must compose, not be replaced.
+    compound = pmd_unit("m^2*s^-1")
+    cubed = power_unit(compound, 3)
+    assert cubed.unitDimension == tuple(d * 3 for d in compound.unitDimension)
+    assert_round_trip(cubed)
+
+    # Halving a squared compound returns the original dimension.
+    halved = power_unit(pmd_unit("m^2*s^2"), 0.5)
+    assert halved.unitDimension == (1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0)
+    assert_round_trip(halved)
+
+
+def test_sqrt_unit_symbol_round_trips() -> None:
+    """``sqrt_unit`` emits the canonical ``sqrt(X)`` form (no LaTeX, no
+    whitespace) so the result re-parses cleanly to itself.
+    """
+    from beamphysics.units import sqrt_unit
+
+    root_m = sqrt_unit(pmd_unit("m"))
+    assert root_m.unitSymbol == "sqrt(m)"
+    assert_round_trip(root_m)
+
+    # Compound interior also round-trips.
+    root_compound = sqrt_unit(pmd_unit("kg*m"))
+    assert root_compound.unitSymbol == "sqrt(kg*m)"
+    assert_round_trip(root_compound)
+
+
+def test_sqrt_symbol_whitespace_normalized() -> None:
+    """Whitespace inside ``sqrt(...)`` is stripped on parse, so all spellings
+    canonicalize to the same stored symbol (and therefore compare equal).
+    """
+    canonical = pmd_unit("sqrt(m)")
+    for spelling in ("sqrt( m )", "  sqrt(m)  ", "sqrt(m )", "sqrt( m)"):
+        u = pmd_unit(spelling)
+        assert u.unitSymbol == "sqrt(m)"
+        assert u == canonical
+        assert hash(u) == hash(canonical)
+
+
+def test_latex_sqrt_form_not_accepted() -> None:
+    """The LaTeX-style ``\\sqrt{...}`` form is not part of the supported unit
+    grammar and must be rejected by the parser.
+    """
+    with pytest.raises(ValueError):
+        pmd_unit(r"\sqrt{m}")
+    with pytest.raises(ValueError):
+        pmd_unit(r"\sqrt{ m }")
+
+
+def test_simplify_skips_compound_numerator() -> None:
+    """``_best_compound_match`` must not propose a compound numerator.
+
+    A product ``compound*atomic`` parses correctly (left-associative), but
+    reads as ``compound`` divided by something to a human — confusing and
+    error-prone. Only ``atomic*atomic`` and ``atomic/atomic`` are emitted.
+    """
+    # Any simplify output must not be of the form "X/Y*Z" or "X*Y/Z" where
+    # one of the operands is itself compound; the constraint we test is the
+    # round-trip property (which would fail under ambiguous emission).
+    for a, b in itertools.product(NAMED_UNITS, NAMED_UNITS):
+        for u in (a * b, a / b):
+            if not _round_trips(u):
+                continue
+            simplified = u.simplify()
+            sym = simplified.unitSymbol
+            # Symbol must be either atomic, or pure compound of atomic
+            # operands joined by * and /. We assert specifically: no operand
+            # within the top-level split is itself compound.
+            from beamphysics.units import _tokenize_compound
+
+            parts, _ops = _tokenize_compound(sym)
+            for p in parts:
+                # Each part must itself contain no top-level * or /.
+                p_parts, _ = _tokenize_compound(p)
+                assert len(p_parts) == 1, f"{sym!r}: token {p!r} is itself compound"
+
+
+@pytest.mark.parametrize("symbol", ["m*", "/m", "m//s", "m**s", "*", "/", "m*/s"])
+def test_parser_rejects_empty_operands(symbol: str) -> None:
+    """Operators with no operand on one side must be flagged, not silently
+    parsed via the empty-string identity.
+    """
+    with pytest.raises(ValueError):
+        pmd_unit(symbol)
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    ["m ^ 2", "m^ 2", "m ^2", "Hz ^ -1", "s^ -2"],
+)
+def test_whitespace_around_caret_tolerated(symbol: str) -> None:
+    """Whitespace around ``^`` must parse the same as the unspaced form."""
+    canonical = pmd_unit(symbol.replace(" ", ""))
+    assert pmd_unit(symbol).unitDimension == canonical.unitDimension
+    assert pmd_unit(symbol).unitSI == canonical.unitSI
+
+
+def test_symbol_whitespace_normalized_in_stored_form() -> None:
+    """Compound symbols with whitespace around operators must canonicalize.
+
+    Without normalization, ``pmd_unit("eV / c") != pmd_unit("eV/c")`` even
+    though they denote the same unit, and they hash differently.
+    """
+    spaced = pmd_unit("eV / c")
+    tight = pmd_unit("eV/c")
+    assert spaced.unitSymbol == tight.unitSymbol == "eV/c"
+    assert spaced == tight
+    assert hash(spaced) == hash(tight)
+
+    # Three-token compound also normalizes.
+    assert pmd_unit("kg * m / s").unitSymbol == "kg*m/s"
+
+
+@pytest.mark.parametrize("bad_si", [-1.0, -1e-30, -0.0001, -1e30])
+def test_negative_unitSI_rejected(bad_si: float) -> None:
+    """The openPMD standard requires unitSI to be a positive conversion
+    factor to SI. A negative value would invert every value written through
+    this unit, so the constructor must reject it.
+    """
+    with pytest.raises(ValueError, match="unitSI must be non-negative"):
+        pmd_unit("bogus", unitSI=bad_si, unitDimension="1")
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected_tex"),
+    [
+        ("", ""),
+        ("1", "1"),
+        ("m", r"\mathrm{m}"),
+        ("eV", r"\mathrm{eV}"),
+        ("eV/c", r"\mathrm{eV}/\mathrm{c}"),
+        ("kg*m/s", r"\mathrm{kg}{\cdot}\mathrm{m}/\mathrm{s}"),
+        ("m^2", r"\mathrm{m}^{2}"),
+        ("s^-1", r"\mathrm{s}^{-1}"),
+        ("m^0.5", r"\mathrm{m}^{0.5}"),
+        ("m^(1/2)", r"\mathrm{m}^{1/2}"),
+        ("sqrt(m)", r"\sqrt{\mathrm{m}}"),
+        ("sqrt(kg*m)", r"\sqrt{\mathrm{kg}{\cdot}\mathrm{m}}"),
+        ("charge #", r"\mathrm{charge #}"),
+    ],
+)
+def test_to_tex_translation(symbol: str, expected_tex: str) -> None:
+    """``to_tex`` is a structural translation only: each atomic name wraps
+    in ``\\mathrm{...}``, ``*`` becomes ``{\\cdot}``, ``/`` stays, ``^N``
+    becomes ``^{N}``, and ``sqrt(X)`` becomes ``\\sqrt{...}``. No
+    simplification, no reordering.
+    """
+    if symbol in ("", "1"):
+        # These can't be round-tripped through pmd_unit() with unitSI=0 (the
+        # empty/identity sentinel), so construct directly.
+        u = pmd_unit(symbol, unitSI=1, unitDimension="1")
+    else:
+        u = pmd_unit(symbol)
+    assert u.to_tex() == expected_tex
+
+
+def test_to_tex_preserves_input_structure() -> None:
+    """``to_tex`` must reflect the *stored* symbol, not the simplified form.
+    A redundant compound stays compound in the TeX output.
+    """
+    u = pmd_unit("m*s/m")  # dimension reduces, but the symbol is preserved
+    assert u.to_tex() == r"\mathrm{m}{\cdot}\mathrm{s}/\mathrm{m}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -10,6 +10,7 @@ from beamphysics.units import (
     dimension,
     nice_array,
     nice_scale_prefix,
+    pg_units,
     plottable_array,
     pmd_unit,
     unit as deprecated_unit,
@@ -93,6 +94,81 @@ def test_simplify_never_breaks_round_trip() -> None:
             assert _round_trips(
                 u.simplify()
             ), f"{u.unitSymbol} -> {u.simplify().unitSymbol}"
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected_si", "base_symbol"),
+    [
+        ("keV", 1e3, "eV"),
+        ("MeV", 1e6, "eV"),
+        ("meV", 1e-3, "eV"),
+        ("mm", 1e-3, "m"),
+        ("cm", 1e-2, "m"),
+        ("kV", 1e3, "V"),
+        ("mg", 1e-3, "g"),  # milli-gram: 1e-3 * gram(1e-3 kg) = 1e-6 kg
+        ("GHz", 1e9, "Hz"),
+        ("mrad", 1e-3, "rad"),
+        ("mA", 1e-3, "A"),
+    ],
+)
+def test_si_prefix_parsing(symbol: str, expected_si: float, base_symbol: str) -> None:
+    base = pmd_unit(base_symbol)
+    u = pmd_unit(symbol)
+    assert u.unitDimension == base.unitDimension
+    assert math.isclose(u.unitSI, expected_si * base.unitSI, rel_tol=1e-12)
+
+
+@pytest.mark.parametrize("symbol", ["k", "M", "da", "k1", "min", "Pa", "xyz"])
+def test_bare_prefix_and_junk_rejected(symbol: str) -> None:
+    # A bare SI prefix is not a unit, and the prefix fallback must not parse
+    # arbitrary strings (the remainder has to be a known unit).
+    with pytest.raises(ValueError):
+        pmd_unit(symbol)
+
+
+def test_prefix_does_not_shadow_base_units() -> None:
+    # Prefix letters that collide with unit symbols must still resolve to the
+    # unit (lookup happens before the prefix fallback): c=speed of light (not
+    # centi), T=tesla (not tera), g=gram, cd=candela.
+    assert math.isclose(pmd_unit("c").unitSI, 299792458.0)
+    assert pmd_unit("c").unitDimension == dimension("velocity")
+    assert pmd_unit("T").unitDimension == dimension("magnetic_field")
+    assert pmd_unit("g").unitDimension == dimension("mass")
+    assert pmd_unit("cd").unitDimension == (0, 0, 0, 0, 0, 0, 1)
+
+
+def test_simplify_prefixed_output_round_trips() -> None:
+    # simplify() emits prefixed atomic symbols (e.g. "mg", "kV"); the parser
+    # must read them back to the same unit.
+    for u in (
+        pmd_unit("g") * pmd_unit("g") / pmd_unit("kg"),  # 1e-6 kg -> "mg"
+        pmd_unit("ratio_v", 1e3, dimension("electric_potential")),  # -> "kV"
+        pmd_unit("ratio_m", 1e-6, dimension("mass")),  # -> "mg"
+    ):
+        simplified = u.simplify()
+        assert _round_trips(simplified), simplified.unitSymbol
+
+
+def test_sqrt_unit_halves_dimension() -> None:
+    # Regression: sqrt_unit used integer floor division (x // 2), so sqrt(m)
+    # collapsed to dimensionless instead of m^0.5.
+    from beamphysics.units import sqrt_unit
+
+    root_m = sqrt_unit(pmd_unit("m"))
+    assert root_m.unitDimension == (0.5, 0, 0, 0, 0, 0, 0)
+    assert math.isclose(root_m.unitSI, 1.0)
+    # x_bar/px_bar are defined via sqrt_unit and document units of sqrt(m).
+    assert pg_units("x_bar").unitDimension == (0.5, 0, 0, 0, 0, 0, 0)
+
+
+def test_cov_units_with_prefixed_subkey() -> None:
+    # Regression: pg_units used key.strip("cov_"), which strips the char set
+    # {c,o,v,_} and mangled subkeys like "charge" -> "harge" (KeyError).
+    u = pg_units("cov_charge__x")
+    assert u.unitDimension == (1, 0, 1, 1, 0, 0, 0)  # charge * length
+    # Order independence and the common case still work.
+    assert pg_units("cov_x__charge").unitDimension == (1, 0, 1, 1, 0, 0, 0)
+    assert pg_units("cov_x__px").unitDimension == (2, 1, -1, 0, 0, 0, 0)
 
 
 def test_parsing_compound_does_not_mutate_named_units() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -206,6 +206,16 @@ def test_sqrt_unit_halves_dimension() -> None:
     assert pg_units("x_bar").unitDimension == (0.5, 0, 0, 0, 0, 0, 0)
 
 
+def test_norm_emit_4d_stored_as_m_squared() -> None:
+    """``norm_emit_4d`` is area-like (m^2). The stored symbol should be
+    ``m^2`` rather than the equivalent-but-clumsy ``m*m`` so plot labels
+    render cleanly."""
+    u = pg_units("norm_emit_4d")
+    assert u.unitSymbol == "m^2"
+    assert u.unitDimension == (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    assert u.unitSI == 1
+
+
 def test_cov_units_with_prefixed_subkey() -> None:
     # Regression: pg_units used key.strip("cov_"), which strips the char set
     # {c,o,v,_} and mangled subkeys like "charge" -> "harge" (KeyError).
@@ -259,6 +269,61 @@ def test_equality_is_value_based_per_standard() -> None:
 
 def test_hashability() -> None:
     assert len({pmd_unit("T"), pmd_unit("eV"), pmd_unit("T")}) == 2
+
+
+def test_pow_operator_matches_power_unit() -> None:
+    """``u ** n`` is sugar for ``power_unit(u, n)`` and must agree on the
+    stored symbol, SI factor, and dimension for both integer and fractional
+    exponents (including compound bases that need distribution)."""
+    from beamphysics.units import power_unit
+
+    for base, exp in [
+        (pmd_unit("m"), 2),
+        (pmd_unit("m"), 0.5),
+        (pmd_unit("eV*s"), 2),
+        (pmd_unit("m^2*s^-1"), 3),
+    ]:
+        via_op = base**exp
+        via_fn = power_unit(base, exp)
+        assert via_op.unitSymbol == via_fn.unitSymbol
+        assert via_op.unitSI == via_fn.unitSI
+        assert via_op.unitDimension == via_fn.unitDimension
+
+
+def test_compatible_with_is_dimension_only() -> None:
+    """``compatible_with`` is a pure-dimension check: equal-dimension units
+    are compatible regardless of SI scale, and non-pmd_unit operands raise."""
+    # Equal dimension, different SI scale -> still compatible.
+    assert pmd_unit("eV").compatible_with(pmd_unit("J"))
+    assert pmd_unit("J").compatible_with(pmd_unit("eV"))
+    # Different syntax, same physical unit.
+    assert pmd_unit("Hz").compatible_with(pmd_unit("1/s"))
+    # Different dimensions -> incompatible.
+    assert not pmd_unit("m").compatible_with(pmd_unit("s"))
+    # Reflexive and symmetric.
+    u = pmd_unit("T*m")
+    assert u.compatible_with(u)
+    # Type guard.
+    with pytest.raises(TypeError):
+        pmd_unit("m").compatible_with("m")
+
+
+def test_conversion_factor_to_round_trips_and_rejects_mismatch() -> None:
+    """``conversion_factor_to`` returns ``self.unitSI / other.unitSI`` after
+    a dimension check; multiplying a value by it must move it from ``self``
+    to ``other``. Incompatible dimensions raise ``ValueError``."""
+    # Same-dimension conversion: 1 eV in joules == e_charge.
+    fac = pmd_unit("eV").conversion_factor_to(pmd_unit("J"))
+    assert fac == pmd_unit("eV").unitSI / pmd_unit("J").unitSI
+    # Round-trip: km -> m -> km.
+    km, m = pmd_unit("km"), pmd_unit("m")
+    assert km.conversion_factor_to(m) == 1000.0
+    assert m.conversion_factor_to(km) == 0.001
+    # Equal units yield factor 1.
+    assert pmd_unit("Hz").conversion_factor_to(pmd_unit("1/s")) == 1.0
+    # Incompatible dimensions raise.
+    with pytest.raises(ValueError, match="Incompatible units"):
+        pmd_unit("m").conversion_factor_to(pmd_unit("s"))
 
 
 def test_divide() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -149,6 +149,42 @@ def test_simplify_prefixed_output_round_trips() -> None:
         assert _round_trips(simplified), simplified.unitSymbol
 
 
+def test_simplify_dimensionless_ratio_not_compound() -> None:
+    # Regression: a pure-number ratio must not be "simplified" into a same-
+    # dimension compound like "kg/g" (mass/mass == 1000). It has no meaningful
+    # named form, so simplify returns it unchanged.
+    u = pmd_unit("mrad/µrad")  # 1000, dimensionless
+    s = u.simplify()
+    assert s.unitDimension == (0, 0, 0, 0, 0, 0, 0)
+    assert s.unitSymbol == u.unitSymbol  # unchanged
+    assert s.unitSI == u.unitSI  # value preserved exactly
+    # An exact-1 dimensionless still collapses to the empty symbol.
+    assert pmd_unit("r", 1.0, (0,) * 7).simplify().unitSymbol == ""
+
+
+def test_ohm_unit_and_alias() -> None:
+    ohm = pmd_unit("Ω")
+    assert ohm.unitDimension == (2, 1, -3, -2, 0, 0, 0)  # V/A
+    assert math.isclose(ohm.unitSI, 1.0)
+    # ASCII alias resolves to the same dimension/value.
+    alias = pmd_unit("Ohm")
+    assert alias.unitDimension == ohm.unitDimension
+    assert math.isclose(alias.unitSI, ohm.unitSI)
+    # simplify recognizes V/A as the ohm, and prefixes/compounds work.
+    assert (pmd_unit("V") / pmd_unit("A")).simplify().unitSymbol == "Ω"
+    assert math.isclose(pmd_unit("kΩ").unitSI, 1e3)
+    assert pmd_unit("Ω/m").unitDimension == (1, 1, -3, -2, 0, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    # Unit strings documented/plotted in the wakefields module must all parse.
+    ["V/C/m", "V/C", "Ohm/m", "Ω/m", "V/pC/m", "MV/m", "1/mm"],
+)
+def test_wakefield_unit_strings_parse(symbol: str) -> None:
+    assert _round_trips(pmd_unit(symbol))
+
+
 def test_sqrt_unit_halves_dimension() -> None:
     # Regression: sqrt_unit used integer floor division (x // 2), so sqrt(m)
     # collapsed to dimensionless instead of m^0.5.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -255,6 +255,57 @@ def test_multiply() -> None:
     assert momentum.unitDimension == dimension("momentum")
 
 
+def test_multiply_same_symbol_round_trips() -> None:
+    """``m * m`` (and longer chains) must produce a re-parseable symbol.
+
+    Previously the s1 == s2 branch emitted ``"(m)^2"``, which the parser
+    rejected because bare parentheses are not a supported grouping.
+    """
+    squared = pmd_unit("m") * pmd_unit("m")
+    assert squared.unitDimension == (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    assert_round_trip(squared)
+
+    cubed = pmd_unit("m") * pmd_unit("m") * pmd_unit("m")
+    assert cubed.unitDimension == (3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    assert_round_trip(cubed)
+
+
+def test_negative_power_normalizes_negative_zero() -> None:
+    """Negative exponents must not produce ``-0.0`` in the dimension tuple.
+
+    ``-1.0 * 0.0 == -0.0`` in IEEE float; while equality and hashing still
+    work, the repr is noisy and dict-key behavior across construction paths
+    is less robust if some tuples carry ``-0.0`` and others ``0.0``.
+    """
+    inv_hz = pmd_unit("1") / pmd_unit("Hz")
+    for i, d in enumerate(inv_hz.unitDimension):
+        assert (
+            math.copysign(1.0, d) == 1.0
+        ), f"dimension index {i} is signed-negative: {d!r}"
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    ["eV / c", " eV/c", "eV/c ", "kg * m / s", "kg*m / s", " V/m "],
+)
+def test_whitespace_around_operators_tolerated(symbol: str) -> None:
+    """Whitespace around operators (and leading/trailing) must parse the same
+    as the unspaced form. Internal whitespace inside a token is not allowed —
+    multi-token named units (e.g. ``"charge #"``) are looked up verbatim."""
+    canonical = pmd_unit(symbol.replace(" ", ""))
+    assert pmd_unit(symbol).unitDimension == canonical.unitDimension
+    assert pmd_unit(symbol).unitSI == canonical.unitSI
+
+
+def test_legacy_multitoken_name_still_parses() -> None:
+    """The ``"charge #"`` legacy entry must still resolve via direct lookup,
+    even though it contains an internal space.
+    """
+    u = pmd_unit("charge #")
+    assert u.unitDimension == dimension("charge")
+    assert u.unitSI == 1
+
+
 @pytest.mark.parametrize(
     ("symbol", "expected_unit"),
     [

--- a/tests/test_units_pint.py
+++ b/tests/test_units_pint.py
@@ -1,0 +1,352 @@
+"""
+Independent verification of ``beamphysics.units`` against `pint`.
+
+`pint` is a mature, widely-used units library. These tests treat it as an
+external oracle: for every named unit, named dimension, and a sampling of
+compound symbols, we check that beamphysics agrees with pint on both the SI
+dimensionality (the 7-tuple of base-unit exponents) and the SI scale factor.
+
+`pint` is a *test-only* dependency. The package itself must not import it, so
+this module skips entirely when pint is unavailable.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+import pytest
+
+pint = pytest.importorskip("pint")
+
+from beamphysics.units import (  # noqa: E402  (after importorskip)
+    DIMENSION,
+    NAMED_UNITS,
+    PARTICLEGROUP_UNITS,
+    SI_symbol,
+    pg_units,
+    pmd_unit,
+)
+
+# beamphysics stores dimensions as a 7-tuple in this order:
+#   (length, mass, time, current, temperature, mol, luminous)
+# Map each pint base-dimension name to its index in that tuple.
+PINT_DIM_INDEX = {
+    "[length]": 0,
+    "[mass]": 1,
+    "[time]": 2,
+    "[current]": 3,
+    "[temperature]": 4,
+    "[substance]": 5,
+    "[luminosity]": 6,
+}
+
+# beamphysics uses a handful of non-standard, openPMD-specific symbols that pint
+# cannot parse directly. Map them to the pint expression matching the unit's
+# *declared* physical meaning (dimension + SI scale).
+SYMBOL_TO_PINT = {
+    "": "dimensionless",
+    "1": "dimensionless",
+    "rad": "radian",
+    "degree": "degree",
+    "c": "speed_of_light",  # declared: dim velocity, unitSI = c_light
+    "vel/c": "speed_of_light",  # ditto (a normalized-velocity label)
+    "charge #": "coulomb",  # declared: dim charge, unitSI = 1
+    "W/rad^2": "W / radian**2",
+    "W/m^2": "W / m**2",
+}
+
+
+def to_pint_expr(symbol: str) -> str:
+    """Translate a beamphysics unit symbol into a pint-parseable expression."""
+    if symbol in SYMBOL_TO_PINT:
+        return SYMBOL_TO_PINT[symbol]
+    # beamphysics writes 'sqrt(X)'; pint has no sqrt function, wants '(X)**0.5'.
+    expr = re.sub(r"sqrt\(([^()]+)\)", r"(\1)**0.5", symbol)
+    # beamphysics writes powers with '^'; pint wants '**'.
+    return expr.replace("^", "**")
+
+
+@pytest.fixture(scope="module")
+def ureg() -> "pint.UnitRegistry":
+    return pint.UnitRegistry()
+
+
+def pint_dimension_tuple(quantity: "pint.Quantity") -> tuple[int, ...]:
+    """Convert a pint quantity's dimensionality to a beamphysics 7-tuple."""
+    dims = [0] * 7
+    for name, exponent in quantity.dimensionality.items():
+        assert name in PINT_DIM_INDEX, f"unexpected pint dimension {name!r}"
+        rounded = round(exponent)
+        assert math.isclose(rounded, exponent), f"non-integer exponent {exponent}"
+        dims[PINT_DIM_INDEX[name]] = rounded
+    return tuple(dims)
+
+
+def pint_dimension_floats(quantity: "pint.Quantity") -> tuple[float, ...]:
+    """Like pint_dimension_tuple but keeps fractional exponents (e.g. m**0.5)."""
+    dims = [0.0] * 7
+    for name, exponent in quantity.dimensionality.items():
+        assert name in PINT_DIM_INDEX, f"unexpected pint dimension {name!r}"
+        dims[PINT_DIM_INDEX[name]] = float(exponent)
+    return tuple(dims)
+
+
+def dimensions_close(a, b, abs_tol: float = 1e-9) -> bool:
+    """Elementwise comparison of two dimension tuples (handles fractions)."""
+    return len(a) == len(b) and all(
+        math.isclose(x, y, abs_tol=abs_tol) for x, y in zip(a, b)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. Named dimensions (the DIMENSION dict) vs pint.
+#    This is the check that would have caught the electric_potential bug.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name", sorted(DIMENSION))
+def test_dimension_matches_pint(name: str, ureg) -> None:
+    symbol = SI_symbol[name]
+    quantity = ureg.Quantity(1, to_pint_expr(symbol)).to_base_units()
+    assert pint_dimension_tuple(quantity) == DIMENSION[name], (
+        f"{name} ({symbol}): beamphysics {DIMENSION[name]} != pint "
+        f"{pint_dimension_tuple(quantity)}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 2. Every named unit vs pint: dimension AND SI scale factor.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "unit", NAMED_UNITS, ids=[u.unitSymbol or "<dimensionless>" for u in NAMED_UNITS]
+)
+def test_named_unit_matches_pint(unit: pmd_unit, ureg) -> None:
+    quantity = ureg.Quantity(1, to_pint_expr(unit.unitSymbol)).to_base_units()
+    assert pint_dimension_tuple(quantity) == unit.unitDimension
+    assert math.isclose(quantity.magnitude, unit.unitSI, rel_tol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Compound-symbol parsing vs pint: independently validates pmd_unit's
+#    operator/power parser and unit arithmetic.
+# --------------------------------------------------------------------------- #
+COMPOUND_SYMBOLS = [
+    "A*s",  # = C
+    "A/s",
+    "kg*m/s",  # momentum
+    "kg*m^2/s^2",  # energy
+    "m/s^2",  # acceleration
+    "J/s",  # = W
+    "J/C",  # = V  (exercises the electric_potential dimension)
+    "V*A",  # = W
+    "V/m",
+    "T*m",
+    "T/m",
+    "C/s",  # = A
+    "W/m^2",
+    "eV/c",
+    "kg/m^3",
+]
+
+
+@pytest.mark.parametrize("symbol", COMPOUND_SYMBOLS)
+def test_compound_symbol_matches_pint(symbol: str, ureg) -> None:
+    bp = pmd_unit(symbol)
+    quantity = ureg.Quantity(1, to_pint_expr(symbol)).to_base_units()
+    assert pint_dimension_tuple(quantity) == bp.unitDimension, (
+        f"{symbol}: beamphysics {bp.unitDimension} != pint "
+        f"{pint_dimension_tuple(quantity)}"
+    )
+    assert math.isclose(quantity.magnitude, bp.unitSI, rel_tol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 4. simplify() preserves physical meaning: the simplified unit must still
+#    agree with pint on dimension and SI scale (independent of the symbol).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("symbol", COMPOUND_SYMBOLS)
+def test_simplify_preserves_physics_vs_pint(symbol: str, ureg) -> None:
+    simplified = pmd_unit(symbol).simplify()
+    quantity = ureg.Quantity(1, to_pint_expr(symbol)).to_base_units()
+    assert pint_dimension_tuple(quantity) == simplified.unitDimension
+    assert math.isclose(quantity.magnitude, simplified.unitSI, rel_tol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 5. SI-prefixed symbols (keV, mm, mrad, GHz, ...) parse to the same dimension
+#    and SI scale that pint computes.
+# --------------------------------------------------------------------------- #
+PREFIXED_SYMBOLS = [
+    "keV",
+    "MeV",
+    "GeV",
+    "meV",
+    "mm",
+    "cm",
+    "µm",
+    "mrad",
+    "GHz",
+    "kHz",
+    "MHz",
+    "mA",
+    "kV",
+    "mg",
+    "ns",
+    "ps",
+    "fs",
+]
+
+
+@pytest.mark.parametrize("symbol", PREFIXED_SYMBOLS)
+def test_prefixed_symbol_matches_pint(symbol: str, ureg) -> None:
+    bp = pmd_unit(symbol)
+    quantity = ureg.Quantity(1, to_pint_expr(symbol)).to_base_units()
+    assert pint_dimension_tuple(quantity) == bp.unitDimension
+    assert math.isclose(quantity.magnitude, bp.unitSI, rel_tol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 6. Fractional powers (sqrt and X^(p/q)) — these arise in practice (e.g.
+#    spectral densities like V/m/Hz^0.5). pint represents them with fractional
+#    dimension exponents, so compare elementwise.
+# --------------------------------------------------------------------------- #
+FRACTIONAL_SYMBOLS = [
+    "m^0.5",
+    "sqrt(m)",
+    "m^(-3/2)",
+    "T*m^0.5",
+    "eV^0.5",
+    "V/m/Hz^0.5",
+    "s^-1",
+]
+
+
+@pytest.mark.parametrize("symbol", ["Ω", "Ω/m", "V/A", "V/C", "V/C/m"])
+def test_impedance_and_wake_units_match_pint(symbol: str, ureg) -> None:
+    # Impedance (ohm = V/A) and wakefield units, cross-checked against pint.
+    bp = pmd_unit(symbol)
+    quantity = ureg.Quantity(1, to_pint_expr(symbol)).to_base_units()
+    assert pint_dimension_tuple(quantity) == bp.unitDimension
+    assert math.isclose(quantity.magnitude, bp.unitSI, rel_tol=1e-9)
+
+
+@pytest.mark.parametrize("symbol", FRACTIONAL_SYMBOLS)
+def test_fractional_power_matches_pint(symbol: str, ureg) -> None:
+    bp = pmd_unit(symbol)
+    quantity = ureg.Quantity(1, to_pint_expr(symbol)).to_base_units()
+    assert dimensions_close(pint_dimension_floats(quantity), bp.unitDimension), (
+        f"{symbol}: beamphysics {bp.unitDimension} != pint "
+        f"{pint_dimension_floats(quantity)}"
+    )
+    assert math.isclose(quantity.magnitude, bp.unitSI, rel_tol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 7. pg_units(): the ParticleGroup-key -> unit lookup table. The expected
+#    SI *dimension* per key is specified independently here (from the physical
+#    meaning of the key, via canonical SI symbols pint parses), so this cross-
+#    check catches a key mapped to the wrong dimension. We compare dimension
+#    only: beamphysics stores energy/momentum in eV / eV-c, not J / kg-m-s.
+# --------------------------------------------------------------------------- #
+_PG_EXPECTED_GROUPS = {
+    "dimensionless": [
+        "n_particle",
+        "status",
+        "id",
+        "n_alive",
+        "n_dead",
+        "beta",
+        "beta_x",
+        "beta_y",
+        "beta_z",
+        "gamma",
+        "bunching",
+        "theta",
+        "bunching_phase",
+        "xp",
+        "yp",
+        "twiss_alpha_x",
+        "twiss_alpha_y",
+        "twiss_etap_x",
+        "twiss_etap_y",
+    ],
+    "s": ["t", "z/c"],
+    "J": [
+        "energy",
+        "kinetic_energy",
+        "mass",  # mass is stored as rest energy
+        "higher_order_energy",
+        "higher_order_energy_spread",
+    ],
+    "kg*m/s": ["px", "py", "pz", "p", "pr", "ptheta"],
+    "m": [
+        "x",
+        "y",
+        "z",
+        "r",
+        "Jx",
+        "Jy",
+        "norm_emit_x",
+        "norm_emit_y",
+        "twiss_beta_x",
+        "twiss_beta_y",
+        "twiss_eta_x",
+        "twiss_eta_y",
+        "twiss_emit_x",
+        "twiss_emit_y",
+        "twiss_norm_emit_x",
+        "twiss_norm_emit_y",
+    ],
+    "C": ["charge", "species_charge", "weight"],
+    "A": ["average_current"],
+    "W": ["power"],
+    "m**2": ["norm_emit_4d"],
+    "m*kg*m/s": ["Lz"],  # angular momentum = length * momentum
+    "m**0.5": ["x_bar", "px_bar", "y_bar", "py_bar"],  # normal-form coords
+    "V/m": ["E", "Ex", "Ey", "Ez", "Etheta", "Er"],
+    "T": ["B", "Bx", "By", "Bz", "Btheta", "Br"],
+    "1/m": ["twiss_gamma_x", "twiss_gamma_y"],
+}
+PG_EXPECTED = {key: expr for expr, keys in _PG_EXPECTED_GROUPS.items() for key in keys}
+
+
+def test_pg_units_expectation_covers_all_keys() -> None:
+    # Completeness guard: a newly added PARTICLEGROUP_UNITS key must also get an
+    # independent expected dimension here, or this test fails and forces review.
+    assert set(PG_EXPECTED) == set(PARTICLEGROUP_UNITS)
+
+
+@pytest.mark.parametrize("key", sorted(PG_EXPECTED))
+def test_pg_units_dimension_matches_pint(key: str, ureg) -> None:
+    bp = pg_units(key)
+    expected = ureg.Quantity(1, PG_EXPECTED[key]).to_base_units()
+    assert dimensions_close(pint_dimension_floats(expected), bp.unitDimension), (
+        f"pg_units({key!r}) dim = {bp.unitDimension}, expected dim of "
+        f"{PG_EXPECTED[key]!r} = {pint_dimension_floats(expected)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        # Operator prefixes preserve the base key's dimension.
+        ("sigma_x", "m"),
+        ("mean_energy", "J"),
+        ("min_px", "kg*m/s"),
+        ("max_z", "m"),
+        ("ptp_t", "s"),
+        ("delta_p", "kg*m/s"),
+        # Covariance multiplies the two sub-key dimensions.
+        ("cov_x__px", "m*kg*m/s"),
+        ("cov_t__t", "s**2"),
+        # startswith-based field keys.
+        ("electricField", "V/m"),
+        ("magneticField", "T"),
+        ("bunching_5", "dimensionless"),
+    ],
+)
+def test_pg_units_derived_keys_match_pint(key: str, expected: str, ureg) -> None:
+    bp = pg_units(key)
+    quantity = ureg.Quantity(1, expected).to_base_units()
+    assert dimensions_close(
+        pint_dimension_floats(quantity), bp.unitDimension
+    ), f"pg_units({key!r}) dim = {bp.unitDimension}, expected {expected!r}"

--- a/tests/test_units_pint.py
+++ b/tests/test_units_pint.py
@@ -50,7 +50,6 @@ SYMBOL_TO_PINT = {
     "rad": "radian",
     "degree": "degree",
     "c": "speed_of_light",  # declared: dim velocity, unitSI = c_light
-    "vel/c": "speed_of_light",  # ditto (a normalized-velocity label)
     "charge #": "coulomb",  # declared: dim charge, unitSI = 1
     "W/rad^2": "W / radian**2",
     "W/m^2": "W / m**2",

--- a/tests/test_units_pint.py
+++ b/tests/test_units_pint.py
@@ -144,6 +144,11 @@ COMPOUND_SYMBOLS = [
     "W/m^2",
     "eV/c",
     "kg/m^3",
+    # Parenthesized grouping (pint parses parens natively).
+    "V/(eV/c)",
+    "J/(A*s)",  # = V
+    "(eV*s)^2",
+    "W/(V/(eV/c))",  # nested group
 ]
 
 

--- a/tests/test_units_pint.py
+++ b/tests/test_units_pint.py
@@ -301,7 +301,8 @@ _PG_EXPECTED_GROUPS = {
         "twiss_norm_emit_y",
     ],
     "C": ["charge", "species_charge", "weight"],
-    "A": ["average_current"],
+    "A": ["average_current", "current"],
+    "C/m": ["density"],  # slice statistics: charge per slice length
     "W": ["power"],
     "m**2": ["norm_emit_4d"],
     "m*kg*m/s": ["Lz"],  # angular momentum = length * momentum


### PR DESCRIPTION
## Summary

Changes to `beamphysics/units.py`:

1. **New named units**: `Hz` and `deg` (alias of `degree`). `T/m` is *not* added as a named unit — see §1.
2. **Bug fix**: `electric_potential` dimension had length and mass exponents swapped.
3. **Improved `pmd_unit.simplify`**: float-tolerant matching, deterministic tie-breaking, and a new compound-unit search that handles `a*b` / `a/b` combinations.
4. **Round-trip safety in `simplify`**: the compound search no longer emits symbols that re-parse to a different unit, and an SI prefix is no longer glued onto a dimensionless symbol. See §4.
5. **Global-state fix**: parsing a compound unit string no longer mutates the shared `NAMED_UNITS` entries in place. See §5.
6. **SI-prefix parsing**: `pmd_unit` now parses prefixed symbols (`keV`, `mm`, `mrad`, `GHz`, …), making `simplify`'s prefixed output round-trip. See §6.
7. **`sqrt_unit` dimension fix**: `sqrt(m)` was collapsing to dimensionless instead of `m^0.5`, mis-typing `x_bar`/`px_bar`/`y_bar`/`py_bar`. See §7.
8. **`cov_` key fix**: `pg_units("cov_charge__x")` raised `KeyError`. See §8.
9. **New named unit `Ω` (ohm)**, with an `Ohm` ASCII alias — impedance, used by the wakefields module. See §9.
10. **Symbol canonicalization & input hardening**: whitespace around operators and inside `sqrt(...)` is normalized; malformed compound inputs (`m*`, `/m`, `m//s`, `m**s`, `\sqrt{m}`) and negative `unitSI` are rejected. See §10.
11. **`power_unit` distributes across compounds**: `(eV*s)^2 → eV^2*s^2` (not the malformed `eV*s^2`). See §11.
12. **`pmd_unit.to_tex()` for plot labels**: structural translation from stored symbol to matplotlib-mathtext; `mathlabel` consumes it at the boundary. See §12.
13. **Value-based equality (openPMD spec)**: `__eq__` compares `(unitDimension, unitSI)`, not the presentational symbol. `pmd_unit("1/s") == pmd_unit("Hz")`. See §13.
14. **API rounding-out**: `__pow__` (`pmd_unit("m") ** 2`), `compatible_with()` (pure-dimension check), and `conversion_factor_to()` (SI factor with dimension guard). `read_dataset_and_unit_h5` now uses these instead of an ad-hoc `assert`, and `norm_emit_4d` is stored as `m^2` rather than `m*m`. See §14.
15. **Removed the redundant `vel/c` named unit**: it was a velocity-dimensioned clone of `c` (`unitSI = c_light`), not a dimensionless β; the legacy `c_light` alias now points at `c`. See §15.
16. **`divide_units` emits round-trip-safe symbols for compound divisors**: dividing by `eV/c` now yields `.../(eV/c)` instead of `.../eV/c` (which the left-associative parser regroups). Same root cause as §4a, fixed at the arithmetic layer. See §16.
17. **Unicode look-alike characters accepted on parse**: both versions of `Ω` (OHM SIGN U+2126 and GREEK CAPITAL OMEGA U+03A9) and of `µ` (GREEK SMALL MU U+03BC and MICRO SIGN U+00B5) parse as the characters the unit tables use. See §17.
18. **Parenthesized grouping in the symbol grammar**: `V/(eV/c)` and `(eV*s)^2` now parse, removing the structural root cause behind the §4a/§11/§16 workarounds. See §18.
19. **Package-wide unit-usage sweep**: a review of every `units` consumer in the package found and fixed several bugs (a float-invariant hole in named units, a `sqrt(m)*sqrt(m)` parse bug, plot labels that mis-prefixed compound symbols, an HDF5 bytes/str symbol mismatch) and applied the new API where ad-hoc code duplicated it. Non-unit bugs found by the same review are split into a follow-up PR. See §19.
20. **Single recursive parser**: `_parse_single_unit` is merged into `from_symbol`, which now recurses on tokens, group/sqrt inners, and power bases. This removes the duplicated lookup/sqrt logic that had already drifted (`sqrt(kg*m)` parsed alone but failed inside `sqrt(kg*m)*s`). See §20.

An independent `pint`-based test suite (`tests/test_units_pint.py`) cross-checks the unit definitions, parser, and `pg_units` table against the `pint` library. `pint` is a **test-only** dependency; the package does not import it.

All tests pass (1796 passed, 1 xpassed), including new regression tests for every fix above.

---

## 1. New named units

Added to `NAMED_UNITS`:

| Symbol | `unitSI` | `unitDimension`            | Notes |
|--------|----------|-----------------------------|-------|
| `Hz`   | 1        | `(0, 0, -1, 0, 0, 0, 0)`    | Inverse seconds. Cannot be built from `*`/`/` of existing names, so naming is required for `pmd_unit("Hz")` to resolve. |

Added to `known_unit` as an alias:

| Symbol | Aliases  | Notes |
|--------|----------|-------|
| `deg`  | `degree` | Common short form seen in element headers (`rf_phase_deg`, `theta0_deg`). |

These cover the units `Hz` (`Bfreq`, `rf_frequency`) and `deg` (`rf_phase_deg`, `theta0_deg`) that appear in common element headers.

`T/m` (`b1_gradient`) is *not* added as a named unit — the improved `simplify()` (see §3) reconstructs `"T/m"` from `T` and `m` automatically, and the parser already handles `pmd_unit("T/m")` through its compound-symbol parsing.

## 2. Bug fix: `electric_potential` dimension

A volt is `J/C = kg·m²·s⁻³·A⁻¹`. The previous entry had length and mass swapped:

```diff
- "electric_potential": (1, 2, -3, -1, 0, 0, 0),  # wrong: L and M swapped
+ "electric_potential": (2, 1, -3, -1, 0, 0, 0),
```

### Verification

Cross-checked against neighbouring dimensions, which are correct:
- `electric_field` (`V/m`): `(1, 1, -3, -1, 0, 0, 0)` — one less length than V.
- `W = V·A = J/s`:        `(2, 1, -3,  0, 0, 0, 0)` — one less current than V.

So `V` must have length 2 and mass 1.

### Bonus

With the dimension corrected, `simplify()` now resolves `V*A → W` and `J/C → V` correctly via the new compound search.

### Compatibility note

Any HDF5 file written by an earlier version that used the old `unitDimension = (1, 2, -3, -1, 0, 0, 0)` for volts is now inconsistent with this package's view of `electric_potential`. `read_unit_h5` still reads them (it trusts the file attributes verbatim), but dimension- compatibility checks against `dimension("electric_potential")` would flag them as mismatched.

## 3. Improved `pmd_unit.simplify`

### Problems with the previous implementation

- Used `factor == 1` and `factor in SHORT_PREFIX` (dict lookup). Float values produced by unit arithmetic (e.g. `(eV/c)*c`) rarely hit those exact comparisons, so simplification silently failed.
- Only matched a *single* named unit's dimension. Even when both factors of a compound were named (`T*m`, `J*s`, `V*A`), nothing simplified.
- First-match ordering meant the output depended on `NAMED_UNITS` ordering when several entries share a dimension (`eV` vs `J`, `eV/m` vs `J/m`, ...).

### New behavior

Two-pass search:

1. **Atomic match.** Find named units whose dimension matches and whose `unitSI` matches the target either exactly or up to a single SI prefix factor (`SHORT_PREFIX_FACTOR`). Comparisons use `math.isclose(..., rel_tol=1e-9)`.
2. **Compound match.** If no atomic match exists, search every named pair `(a, b)` (both with nonzero dimension) for an exact `a*b` or `a/b` whose dimension and `unitSI` match the target.

Among candidates the simplest is returned, using the sort key `(has_operators, length, lexicographic)` — so atomic beats compound, shorter beats longer, and ties are deterministic.

If nothing matches, `self` is returned (unchanged behavior).

### New helpers (module-private)

- `_SIMPLIFY_REL_TOL = 1e-9`
- `_symbol_complexity(symbol)` — sort key for candidate ranking.
- `_closest_prefix(factor)` — float-tolerant SI prefix lookup.
- `_best_atomic_match(target_dim, target_si, named_units)`
- `_best_compound_match(target_dim, target_si, named_units)`

### Examples

```python
>>> ((pmd_unit("eV/c") * pmd_unit("c")).simplify())   # was failed silently
pmd_unit('eV', 1.602176634e-19, (2, 1, -2, 0, 0, 0, 0))

>>> (pmd_unit("T") * pmd_unit("m")).simplify()        # NEW: compound search
pmd_unit('T*m', 1, (1, 1, -2, -1, 0, 0, 0))

>>> (pmd_unit("V") * pmd_unit("A")).simplify()        # NEW: needs V fix + compound
pmd_unit('W', 1, (2, 1, -3, 0, 0, 0, 0))

>>> ((pmd_unit("T") / pmd_unit("m") / pmd_unit("m")) * pmd_unit("m")).simplify()
pmd_unit('T/m', 1, (-1, 1, -2, -1, 0, 0, 0))
```

### Performance

The compound search builds a `dim -> [pmd_unit]` index once and iterates through `~N` named units, doing dict lookups for compatible partners. Worst-case cost is `O(N²)` for `N ≈ 30` named units, which is trivial.

## 4. Round-trip safety in `simplify`

The symbol parser is **left-associative**: `"a/b/c"` means `(a/b)/c`. (At this point in the PR it had no parenthesized grouping; §18 adds that later.) The first draft of the compound search and the prefix logic could both produce a symbol *string* whose stored `(unitSI, unitDimension)` were correct but which re-parsed to a *different* unit. Two cases were fixed.

### 4a. Division by a compound divisor

When the divisor `b` already contains an operator, `f"{a}/{b}"` is wrong:

```python
# before: dim/si forced to target, but the SYMBOL lies
>>> (pmd_unit("V/m") / pmd_unit("W")).simplify()
pmd_unit('T/J/m', 1.0, (-1, 0, 0, -1, 0, 0, 0))
>>> pmd_unit('T/J/m')                       # 'T/J/m' == (T/J)/m, not T/(J/m)
pmd_unit('T/J/m', 1.0, (-3, 0, 0, -1, 0, 0, 0))   # different dimension!
```

Fix: `_best_compound_match` now skips any divisor whose symbol contains `*` or `/`. The `a*b` form is unaffected — a product chain is associative under the parser's grouping, so `a*b` always round-trips.

```python
>>> (pmd_unit("V/m") / pmd_unit("W")).simplify()
pmd_unit('V/m/W', 1.0, (-1, 0, 0, -1, 0, 0, 0))   # round-trips
```

### 4b. SI prefix on a dimensionless symbol

A prefix on a dimensionless unit produced a bare prefix glued to the empty symbol, which is wrong or unparseable:

```python
# before
>>> pmd_unit("ratio", 1e-3, (0,)*7).simplify()
pmd_unit('m', 0.001, (0, 0, 0, 0, 0, 0, 0))   # 'm' re-parses as METERS
>>> pmd_unit("ratio", 1e3, (0,)*7).simplify()
pmd_unit('k', 1000.0, (0, 0, 0, 0, 0, 0, 0))  # 'k' is unparseable
```

Fix: `_best_atomic_match` no longer applies a prefix to a dimensionless unit. Only an exact (unprefixed) dimensionless match is accepted; otherwise the search falls through to the compound pass or returns `self`.

A brute-force check over every `a*b` / `a/b` of the named units confirms that `simplify()` never turns a round-tripping unit into a non-round-tripping one.

## 5. Global-state fix: parsing no longer mutates `NAMED_UNITS`

**Pre-existing bug, independent of this PR** (also present on `master`), but surfaced by the new `simplify` tests, which are the first to rely on `NAMED_UNITS` integrity within a process.

`pmd_unit._parse_single_unit` returned the **shared** cached unit object, and `from_symbol` then reassigned `result._unitSymbol`. Because `rad` is an identity unit (`unitSI == 1`, dimensionless), `multiply_units` returns its operand unchanged, so parsing a string like `"m*rad"` rewrote the **global** `"m"` entry's symbol to `"m*rad"` — silently corrupting every later `simplify()` call in the same process:

```python
>>> import beamphysics.units as U
>>> pmd_unit("m*rad")
>>> [u.unitSymbol for u in U.NAMED_UNITS if u.unitSI == 1][:4]
['', 'degree', 'rad', 'm*rad']   # 'm' was clobbered
```

Fix: `_parse_single_unit` returns a copy of the cached unit instead of the shared object (mirroring what `from_symbol` already does for direct lookups). Parsing is now side-effect-free.

## 6. SI-prefix parsing

Previously `pmd_unit` could not parse prefixed symbols — `pmd_unit("keV")`, `"mm"`, `"mrad"`, `"GHz"` all raised `Unknown unitSymbol`. This was also an asymmetry bug: `simplify()` *emits* prefixed atomic symbols (`"mg"`, `"kV"`), so e.g. `(g*g/kg).simplify()` produced `"mg"`, which then failed to re-parse.

Fix: `_parse_single_unit` gained an SI-prefix fallback as its last step. After exact lookup / `sqrt` / `^power` fail, it tries each prefix (longest first, so `da` beats `d`) and accepts `prefix + remainder` **only when the remainder is itself a known unit**. This is the exact inverse of what `simplify()` emits, so prefixed output now always round-trips.

```python
>>> pmd_unit("MeV").unitSI, pmd_unit("MeV").unitDimension
(1.602176634e-13, (2, 1, -2, 0, 0, 0, 0))
>>> (pmd_unit("g") * pmd_unit("g") / pmd_unit("kg")).simplify()
pmd_unit('mg', 1e-06, (0, 1, 0, 0, 0, 0, 0))   # now re-parses correctly
```

Rules (by design):

- A bare prefix is **not** a unit: `"k"`, `"M"`, `"da"`, `"k1"` still raise.
- Lookup happens before the fallback, so prefix letters that are also unit symbols keep their unit meaning: `c` = speed of light (never centi), `T` = tesla, `g` = gram, `cd` = candela.
- `Tm` parses as tera-meter. Tesla·meter must be written `T*m` (the package already requires `*` for products), so adjacency like `Tm` is a user error and is intentionally not second-guessed.

## 7. `sqrt_unit` dimension fix

`sqrt_unit` computed the result dimension with integer floor division (`x // 2`), so `sqrt(m)` (dimension `(1, 0, …)`) collapsed to `(0, 0, …)` — **dimensionless** instead of `m^0.5`. This mis-typed the `pg_units` entries built from it: `x_bar`, `px_bar`, `y_bar`, `py_bar`, which `particles.py` documents as having units of `sqrt(m)`.

```diff
- dim = tuple(x // 2 for x in u.unitDimension)   # 1 // 2 == 0
```

Fix: `sqrt_unit` now delegates to `power_unit(u, 0.5)`, which scales the exponents by `0.5` (so `m` → `m^0.5`) while preserving the `\sqrt{…}` display symbol. To make fractional exponents survive the round trip through the constructor, `Dimension` is now uniformly a 7-tuple of floats and `make_dimension` coerces to `float` (instead of `int`). This also matches the openPMD standard, which specifies `unitDimension` as "array of 7 *(float64 / REAL8)*". `pg_units("x_bar")` is now `(0.5, 0.0, …)`, and `x_bar**2` correctly gives length.

## 8. `cov_` key fix in `pg_units`

`pg_units` parsed covariance keys with `key.strip("cov_")`. `str.strip` removes any leading/trailing characters in the set `{c, o, v, _}` — not the prefix `"cov_"` — so a subkey beginning with one of those letters was mangled:

```python
>>> pg_units("cov_charge__x")   # before
KeyError: 'harge'               # "charge" -> "harge"
```

Fix: use `key.removeprefix("cov_")`, which strips exactly the prefix.

## 9. New named unit: `Ω` (ohm)

The wakefields module documents impedance in `[Ohm/m]` and plots `Z(k)` in `Ω/m`, but `pmd_unit("Ω")` / `pmd_unit("Ohm")` raised `Unknown unitSymbol` — so those unit strings were never expressible through the units machinery.

Added `Ω` to `NAMED_UNITS` with dimension `(2, 1, -3, -2, 0, 0, 0)` (ohm = V/A), plus an `Ohm` ASCII alias in `known_unit` (mirroring the `deg`/`degree` precedent). Consequences:

```python
>>> pmd_unit("Ω/m").unitDimension       # impedance per length
(1.0, 1.0, -3.0, -2.0, 0.0, 0.0, 0.0)
>>> pmd_unit("kΩ").unitSI                # prefixes work
1000.0
>>> (pmd_unit("V") / pmd_unit("A")).simplify()
pmd_unit('Ω', 1, (2.0, 1.0, -3.0, -2.0, 0.0, 0.0, 0.0))
```

Only `Ω` was added: it is the one missing unit with actual in-repo usage. Other absent SI units (`N`, `Pa`, `Wb`, `F`, `S`, ...) are not referenced anywhere and force is already covered by the named `eV/m` / `J/m`.

A regression test also asserts that every unit string the wakefields module documents/plots (`V/C/m`, `Ohm/m`, `Ω/m`, `V/pC/m`, `MV/m`, `1/mm`, ...) is a valid `pmd_unit` symbol, keeping those annotations consistent with the units system.

## 10. Symbol canonicalization & input hardening

The parser and constructor now reject several malformed inputs that previously silently parsed via the identity unit, and canonicalize whitespace on the way in so trivially-different spellings of the same unit hash and compare equal.

### Whitespace normalization

Whitespace around operators (`*`, `/`), around `^` exponents, and inside `sqrt(...)` is stripped during parsing, so the **stored** `unitSymbol` is whitespace-free:

```python
>>> pmd_unit("eV / c").unitSymbol
'eV/c'
>>> pmd_unit("kg * m / s").unitSymbol
'kg*m/s'
>>> pmd_unit("m ^ 2").unitDimension
(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
>>> pmd_unit("sqrt( m )").unitSymbol
'sqrt(m)'
```

Combined with the value-based equality in §13, this means `pmd_unit("eV / c") == pmd_unit("eV/c")` and they share a hash.

### Malformed inputs rejected

Previously `"m*"` silently parsed as `m * 1 = m` because the empty operand resolved to the identity unit; `"/m"` became `1/m`; `r"\sqrt{m}"` was accepted by an experimental LaTeX branch. All now raise `ValueError`:

```python
>>> pmd_unit("m*")        # empty operand around '*'
ValueError: Malformed unit symbol 'm*': empty operand around an operator.
>>> pmd_unit("m**s")      # double operator -> empty operand between
ValueError: ...
>>> pmd_unit(r"\sqrt{m}") # only the sqrt(...) form is accepted
ValueError: Unknown unitSymbol: ...
```

The `\sqrt{...}` parser branch was removed: only the canonical `sqrt(<inner>)` form is accepted on input, and `sqrt_unit` / the sqrt parser canonicalize whitespace inside to that same form on output.

### Negative `unitSI` rejected

The openPMD standard defines `unitSI` as a conversion factor to SI. A negative scale would invert the sign of every value an instrument writes through the unit, so the constructor now rejects it (zero is still accepted as the sentinel that triggers symbol lookup):

```python
>>> pmd_unit("bogus", unitSI=-1.0, unitDimension="1")
ValueError: unitSI must be non-negative (got -1.0). The openPMD standard
defines unitSI as a conversion factor to SI.
```

## 11. `power_unit` distributes across compound symbols

Writing `f"{symbol}^{n}"` for a compound symbol produces the wrong unit: `"eV*s^2"` parses as `eV*(s^2)`, not `(eV*s)^2`. `power_unit` distributes the exponent across each token and re-emits, so the symbol always round-trips and matches the dimension (the distributed `eV^2*s^2` is preferred over the also-valid `(eV*s)^2` as the conventional spelling):

```python
>>> power_unit(pmd_unit("eV*s"), 2)
pmd_unit('eV^2*s^2', 2.567e-38, (4.0, 2.0, -2.0, 0.0, 0.0, 0.0, 0.0))
>>> power_unit(pmd_unit("m^2*s^-1"), 3)
pmd_unit('m^6*s^-3', 1.0, (6.0, 0.0, -3.0, 0.0, 0.0, 0.0, 0.0))
>>> power_unit(pmd_unit("m^2*s^2"), 0.5)   # halving the compound is also correct
pmd_unit('m*s', 1.0, (1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0))
```

`sqrt_unit` now uses the canonical `sqrt(<inner>)` form (no LaTeX, no whitespace) so it round-trips through the parser. Internal helpers added: `_tokenize_compound`, `_join_compound`, `_distribute_power_in_symbol`, `_combine_token_power`, `_format_power`, `_is_atomic_symbol`.

`_best_compound_match` was tightened in step: both the numerator and divisor of an emitted `a*b` / `a/b` must be **atomic** (no top-level `*`/`/`). A compound numerator parses correctly but reads ambiguously to a human (`"J/m*s"` left-associates to `(J/m)*s`, but looks like `J/(m*s)`); restricting to atomic operands keeps the emitted symbol unambiguous.

## 12. `pmd_unit.to_tex()` for plot labels

`pmd_unit` now has a `to_tex()` method that renders the stored symbol as a matplotlib-mathtext fragment. The translation is **purely structural** — no algebraic simplification, no reordering: each atomic name is wrapped in `\mathrm{...}`, `*` becomes `{\cdot}`, `/` stays, `^N` becomes `^{N}`, `^(n/d)` becomes `^{n/d}`, and `sqrt(X)` becomes `\sqrt{...}` (recursing on the inner expression).

```python
>>> pmd_unit("eV/c").to_tex()
'\\mathrm{eV}/\\mathrm{c}'
>>> pmd_unit("kg*m/s").to_tex()
'\\mathrm{kg}{\\cdot}\\mathrm{m}/\\mathrm{s}'
>>> pmd_unit("sqrt(kg*m)").to_tex()
'\\sqrt{\\mathrm{kg}{\\cdot}\\mathrm{m}}'
>>> pmd_unit("m*s/m").to_tex()             # preserves stored structure
'\\mathrm{m}{\\cdot}\\mathrm{s}/\\mathrm{m}'
```

`beamphysics/labels.py::mathlabel` was updated to consume `to_tex()` when wrapping a `pmd_unit` (or a str that parses to one). This restores matplotlib's `\sqrt{...}` glyph rendering for `sqrt_unit(pmd_unit("m"))` quantities like `x_bar`, which would otherwise have shown the literal `sqrt(m)` text after the §10 sqrt-canonicalization removed the LaTeX-wrapped storage form.

Two edge cases in `mathlabel` are handled explicitly (both caught in review of an earlier draft of this PR):

- **Unparseable unit strings** (e.g. `units="foo*bar"`) fall back to `\mathrm{...}` with `*` still replaced by `{\cdot}`, matching the pre-`to_tex` behavior.
- **Dimensionless units in the non-TeX branch**: a `pmd_unit` object is always truthy, so the `tex=False` branch gated on the object would emit `"x ()"` for a unit with an empty symbol. It now gates on `str(units)`, so a dimensionless unit adds no annotation (matching the TeX branch and the pre-PR behavior).

## 13. Value-based equality (openPMD spec)

The openPMD standard defines a unit by its `unitSI` and `unitDimension`; the symbol is presentational. `__eq__` now follows that convention — two units compare equal when they share the same dimension and (within a small relative tolerance) the same SI factor, regardless of how their symbols were spelled:

```python
>>> pmd_unit("1/s") == pmd_unit("Hz")              # different syntax, same unit
True
>>> pmd_unit("s^-1") == pmd_unit("Hz")
True
>>> pmd_unit("eV/c") * pmd_unit("c") == pmd_unit("eV")   # arithmetic round-trip
True
>>> pmd_unit("J") == pmd_unit("eV")                # same dim, different SI scale
False
```

Both `__eq__` and `__hash__` derive `unitSI` from a single canonical key, `_canonical_unitSI`, which quantizes the factor to 12 significant figures. This absorbs the ULP-level drift of arithmetic chains like `(eV/c) * c` (so they still satisfy `== eV`) while giving a **transitive** equality — unlike a bare `math.isclose`, which is not transitive and cannot be made consistent with any finer-than-dimension hash (two values within tolerance can straddle a rounding boundary, breaking `a == b ⟹ hash(a) == hash(b)`).

`__hash__` therefore keys on `(unitDimension, _canonical_unitSI(unitSI))`. Hashing on the dimension *alone* would be correct but would funnel every same-dimension unit (`eV`, `J`, `keV`, `MeV`, …) into a single bucket; including the canonical SI key keeps distinct scales in distinct buckets while preserving the invariant. Sets and dicts de-duplicate correctly:

```python
>>> len({pmd_unit("1/s"), pmd_unit("Hz")})            # equal -> de-duplicated
1
>>> len({hash(pmd_unit(u)) for u in ("eV", "J", "keV", "MeV")})  # distinct buckets
4
```

### Downstream impact

This is the one change in this PR that can alter downstream behavior without raising an error: any code using `pmd_unit` objects as dict keys or in sets where symbol-distinct-but-value-equal units (`"1/s"` vs `"Hz"`, `"m*m"` vs `"m^2"`) previously stayed separate will now silently merge them. This is the openPMD-correct semantics, but it deserves a prominent line in the release notes/changelog.

### Why not auto-simplify on construction?

An earlier draft considered canonicalizing the stored symbol on construction (so `pmd_unit("1/s")` would store as `Hz`). Rejected: it loses user-supplied structure that `to_tex()` and downstream consumers may want to preserve (`pmd_unit("m*s/m").unitSymbol == "m*s/m"`), pays the `simplify()` cost on every construction, and creates a coin-flip when two named units share `(unitSI, unitDimension)` (Hz vs Bq). Value-based equality is the openPMD-compliant fix without those costs.

### Newton (`N`) not added

`N` (force, `unitSI=1`, dim `(1,1,-2,0,0,0,0)`) was considered for `NAMED_UNITS`. It does *not* conflict with `eV/m` / `MeV/m` as previously thought — those have `unitSI = n * e_charge`, which is not within `rel_tol=1e-9` of any SI-prefix factor times `N=1`, so the prefix fallback in `_best_atomic_match` never reaches `N` for eV-scale forces. The actual conflict is in `_best_compound_match`: `N/A` (also kg·m·A⁻¹·s⁻²) would beat `T*m` lexicographically and silently change `simplify(T*m) → N/A` — breaking the conventional magnetic-rigidity spelling. Until the compound matcher gets a bias for accelerator-physics-familiar spellings, `N` stays out and SI-magnitude forces continue to simplify to `J/m`. The comment in `NAMED_UNITS` was corrected to reflect this (the previous comment incorrectly blamed `eV/m`).

## 14. API rounding-out: `__pow__`, `compatible_with`, `conversion_factor_to`

Three small additions complete the operator/dunder set and replace ad-hoc dimension checks scattered in the package with named methods.

### `__pow__`

`pmd_unit` now supports the `**` operator, delegating to the existing `power_unit` (so the §11 compound-distribution semantics carry over for free):

```python
>>> pmd_unit("m") ** 2
pmd_unit('m^2', 1, (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
>>> pmd_unit("eV*s") ** 2                  # distributes across the compound
pmd_unit('eV^2*s^2', 2.567...e-38, (4.0, 2.0, -2.0, 0.0, 0.0, 0.0, 0.0))
>>> pmd_unit("m^2*s^2") ** 0.5
pmd_unit('m*s', 1.0, (1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0))
```

The table entry for `norm_emit_4d` switches from `pmd_unit("m") * pmd_unit("m")` (stored symbol `"m*m"`) to `pmd_unit("m") ** 2` (stored symbol `"m^2"`). Equality is unaffected by §13, but plot labels rendered through `to_tex()` are now `\mathrm{m}^{2}` instead of `\mathrm{m}{\cdot}\mathrm{m}`.

### `compatible_with(other)`

Pure-dimension check, separate from `==`. Two units are compatible iff they share `unitDimension`; SI scale is ignored. This is what the user usually wants when asking "are these the same kind of quantity?":

```python
>>> pmd_unit("eV").compatible_with(pmd_unit("J"))     # same dim, different SI
True
>>> pmd_unit("Hz").compatible_with(pmd_unit("1/s"))   # same dim, same SI
True
>>> pmd_unit("m").compatible_with(pmd_unit("s"))
False
```

The relationship to `==` is `a == b → a.compatible_with(b)` but not the converse: `eV == J` is `False`, while `eV.compatible_with(J)` is `True`. Non-`pmd_unit` arguments raise `TypeError`.

### `conversion_factor_to(other)`

Returns the multiplicative factor mapping values from `self` to `other`. Equivalent to `self.unitSI / other.unitSI`, but guarded by a `compatible_with` check that raises `ValueError` on dimension mismatch:

```python
>>> pmd_unit("eV").conversion_factor_to(pmd_unit("J"))
1.602176634e-19
>>> pmd_unit("km").conversion_factor_to(pmd_unit("m"))
1000.0
>>> pmd_unit("Hz").conversion_factor_to(pmd_unit("1/s"))
1.0
>>> pmd_unit("m").conversion_factor_to(pmd_unit("s"))
ValueError: Incompatible units: 'm' (dimension (1.0, 0.0, ...)) cannot be converted to 's' (dimension (0.0, 0.0, 1.0, ...)).
```

### Call-site cleanup

`read_dataset_and_unit_h5` previously did:

```python
du = u / expected_unit
assert du.unitDimension == (0, 0, 0, 0, 0, 0, 0), "incompatible units"
if convert:
    fac = du.unitSI
    ...
```

The `assert` (a) is stripped under `python -O`, (b) gives a useless error message, and (c) constructs a throwaway `pmd_unit` just to read its two fields. It now reads:

```python
if not u.compatible_with(expected_unit):
    raise ValueError("Incompatible units: ...")
if convert:
    fac = u.conversion_factor_to(expected_unit)
    ...
```

No new behavior for callers passing matching units; mismatched units now raise `ValueError` with a descriptive message instead of `AssertionError` (or silently passing under `-O`).

## 15. Removed redundant `vel/c` named unit

`NAMED_UNITS` carried both `c` and `vel/c`, defined identically — dimension *velocity* `(1, 0, -1, 0, 0, 0, 0)`, `unitSI = c_light`:

```python
pmd_unit("c", c_light, "velocity"),    # speed of light
pmd_unit("vel/c", c_light, "velocity"),
```

Under the value-based equality of §13 these are the *same* unit (`pmd_unit("vel/c") == pmd_unit("c")`), so `vel/c` was a duplicate. Its symbol is also misleading: `vel/c` reads as relativistic β = v/c, but β is **dimensionless** — and is already correctly represented as `pmd_unit("1")`, which is what `pg_units` uses for `beta`, `beta_x`, `beta_y`, `beta_z`. As a velocity-dimensioned clone of `c`, `vel/c` was never actually used for β; its only consumer was the legacy `c_light` alias key. Finally, the symbol can't round-trip on its own (`vel` is not a known unit), and it was the one compound named-unit operand that `_best_atomic_match` could prefix into a non-round-tripping form such as `kvel/c`.

Fix: drop `vel/c` from `NAMED_UNITS` and repoint the legacy alias at `c`:

```diff
- pmd_unit("c", c_light, "velocity"),  # Speed of light
- pmd_unit("vel/c", c_light, "velocity"),
+ pmd_unit("c", c_light, "velocity"),  # Speed of light
...
- "c_light": pmd_unit("vel/c", c_light, "velocity"),
+ "c_light": known_unit["c"],
```

`pmd_unit("c_light")` still resolves (→ symbol `c_light`, `unitSI = c_light`), so the alias keeps working. Any HDF5 file that stored the literal `"vel/c"` symbol still reads correctly, since `read_unit_h5` reconstructs from `unitSI` + `unitDimension` rather than re-parsing the symbol string.

## 16. `divide_units` emits round-trip-safe symbols for compound divisors

§4a fixed the compound-divisor regrouping problem in `simplify()`'s *output*, but unit arithmetic itself could still produce a lying symbol: under the left-associative parser, `pmd_unit("V/m") / pmd_unit("eV/c")` emitted `"V/m/eV/c"`, which re-parses as `((V/m)/eV)/c` — a different dimension than the stored (correct) one. The in-memory object was always right; only the symbol string failed to round-trip.

Fix: a compound divisor is wrapped in parentheses, which the parser now understands as grouping (§18):

```python
>>> (pmd_unit("V/m") / pmd_unit("eV/c")).unitSymbol   # was "V/m/eV/c"
'V/m/(eV/c)'                                          # round-trips
```

A compound *numerator* needs no such handling: appended operators apply to the whole accumulated value under left association, so `a*b/c...` chains were already correct. An empty numerator symbol (the dimensionless identity) is now emitted as `"1"` (`"1/m"`, not the malformed `"/m"` that §10's parser hardening would reject).

(An earlier revision of this PR distributed the division across the divisor's tokens instead, emitting `"V/m/eV*c"` — correct but hard to read. Once the parser learned parenthesized grouping, the wrapped form became both simpler and clearer.)

## 17. Unicode look-alike characters accepted on parse

The §9 ohm uses U+03A9 GREEK CAPITAL OMEGA (the codepoint Unicode itself recommends — NFC normalizes U+2126 OHM SIGN *to* U+03A9), and `SHORT_PREFIX_FACTOR` keys micro on U+00B5 MICRO SIGN. But users paste whichever variant their keyboard/PDF produces, and the visually identical sibling codepoints were rejected with `Unknown unitSymbol`.

`from_symbol` now folds homoglyphs before lookup: NFC normalization (which maps OHM SIGN → GREEK OMEGA) plus an explicit GREEK SMALL MU (U+03BC) → MICRO SIGN (U+00B5) translation:

```python
>>> pmd_unit("Ω") == pmd_unit("Ω")   # OHM SIGN == GREEK OMEGA
True
>>> pmd_unit("μm").unitSI                  # Greek mu parses as micro
1e-06
```

The stored symbol is the folded form, so either spelling hashes and compares identically. The direct-construction path (`unitSI != 0`) stores symbols verbatim, consistent with how whitespace canonicalization (§10) is also parse-only.

## 18. Parenthesized grouping in the symbol grammar

The parser was flat and left-associative with no grouping: `"V/eV/c"` could only mean `(V/eV)/c`, and `V/(eV/c)` was inexpressible. That single limitation was the structural root cause of a string of workarounds in this PR — `power_unit`'s exponent distribution (§11), `simplify`'s atomic-operand restriction (§4a/§11), and `divide_units`' divisor handling (§16) all exist because a sub-expression couldn't be written as one operand.

The grammar now supports parentheses:

- **`(expr)` as an operand.** `_parse_single_unit` recognizes a balanced parenthesized token and recursively parses the inner expression via `from_symbol`. The tokenizer already refused to split inside parens, so `"V/(eV/c)"` tokenizes as `["V", "(eV/c)"]` and the group divides as a unit:

  ```python
  >>> pmd_unit("V/(eV/c)").unitDimension     # V / (eV/c)
  (1.0, 0.0, -2.0, -1.0, 0.0, 0.0, 0.0)
  >>> pmd_unit("V/eV/c").unitDimension       # (V/eV)/c — different!
  (-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0)
  ```

- **`(expr)^N` and `(expr)^(n/d)`.** The existing power branches recurse on their base, which now lands in the paren branch — so group exponentiation works with no extra code: `pmd_unit("(eV*s)^2") == pmd_unit("eV*s") ** 2`, and `"(m^2*s^2)^(1/2)"` is `m*s`.

- **Canonicalization.** Whitespace inside a group is normalized (`"V / ( eV / c )"` stores as `"V/(eV/c)"`), redundant parens around an atomic token are dropped (`"V/(m)"` → `"V/m"`), and nesting works (`"W/(V/(eV/c))"`).

- **Malformed input rejected.** `"()"`, `"V/()"`, `"(m"`, `"m)"`, `"(a)(b)"`, and `"(m*)"` all raise `ValueError`. A balanced-parens guard keeps adjacent groups from mis-matching as one group.

- **`to_tex` renders groups.** `pmd_unit("V/(eV/c)").to_tex()` → `\mathrm{V}/(\mathrm{eV}/\mathrm{c})`.

Old files are unaffected in both directions: symbols written by earlier versions contain no parens, and `read_unit_h5` reconstructs units from `unitSI` + `unitDimension` rather than re-parsing symbols. The §11 distribution and §4a restrictions are kept as-is (distribution gives the more conventional `eV^2*s^2` spelling for powers; `simplify` output stays atomic-only for readability) — parens simply make the grammar able to express grouping where it matters, and `divide_units` (§16) now uses them.

## 19. Package-wide unit-usage sweep

A review of every consumer of `beamphysics.units` across the package (particles, statistics, standards, plot, labels, readers, writers, fieldmesh, interfaces, wakefields). Fixes, in rough order of severity:

### Bugs fixed

- **Float-invariant hole in named units** (`units.py`): the constructor's *string*-dimension path returned the raw int tuples from `DIMENSION`, so every `NAMED_UNITS` entry carried int dims and an int `unitSI` — and `write_unit_h5` emitted **int64** HDF5 attrs where openPMD specifies float64. `dimension()` now coerces through `make_dimension`, `unitSI` is coerced to `float`, and `write_unit_h5` writes explicit `float64` attrs. A regression test asserts every construction path is float-typed.
- **`sqrt(m)*sqrt(m)` failed to parse** (`units.py`): the whole-string `sqrt(...)` match consumed the product as one sqrt with inner `m)*sqrt(m`. Both sqrt branches now require balanced parens in the inner expression (same guard as the paren-group branch). Found because covariance units like `cov_x_bar__x_bar` produce exactly this symbol.
- **Plot labels glued SI prefixes onto compound symbols** (`plot.py`): `prefix + symbol` is wrong for powered/sqrt/reciprocal symbols (`'m'+'m^2'` reads as `(mm)² = 1e-6` while the data scale is 1e-3 — including a label introduced in this PR by the `norm_emit_4d` `m*m → m^2` change; `'m'+'sqrt(m)'` is unparseable). The scaling-to-symbol logic is the single method `pmd_unit.scaled_symbol(factor)`: the given spelling is kept when an SI prefix can express the factor on it (`meV/c`, `MV/m`), the scaled value re-spells via `simplify` when it cannot (`1e-6 * mA*s` → `nC`, `1e3 * 1/s` → `kHz`), and the factor is written out otherwise (`1e-3 m^2`). Callers pass the scale factor that `nice_array`/`nice_scale_prefix`/`plottable_array` already return — no prefix-string round trips. Unparseable user unit strings are handled only at the one boundary where they arrive, `plottable_array_and_units` (degrading to `'1e3 counts'`). `plot.py` keeps only the plot-domain `_charge_density_units_str` policy; the units→TeX rendering lives inside `mathlabel` (which, with no keys, returns a units-only label). A combined `units.plottable_array_and_units(x, units, ...)` returns the scaled array together with its display-units string, so no plot call site handles a bare SI prefix or factor-to-prefix conversion anymore (~10 two-step sites collapsed, including two missed hand-glued labels in `wakefield_plot`). `labels.texlabel`'s never-taken `None` return was removed from its docstring along with `mathlabel`'s dead `or`-fallback. The marginal/density histogram labels keep each axis's own prefix in the denominator, as before — `nC/µm` against an x axis in µm, `pC/(keV/c)` against keV/c (now with correct grouping; the bare `C/keV/c` would misread) — with the time axis still special-cased to amps. The CDF label no longer double-prefixes (`1e-6·mA·s` now labels `µC`, not `µmC`).
- **HDF5 unitSymbol bytes/str mismatch** (`writers.py` + `units.py`): `write_component_data` wrote `np.bytes_` symbols that `read_unit_h5` never decoded, so units read back from package-written files had bytes symbols (`u * pmd_unit('s')` raised `TypeError`). `write_component_data` now delegates to `write_unit_h5` (UTF-8 str, required for `Ω`/`µ`), and `read_unit_h5` decodes bytes from older files.
- **`is_constant_component` precedence** (`readers.py`): `"value" and "shape" in h5.attrs` only checked `shape`.
- **`nice_scale_prefix` leaked `np.float64`** into its public return; now a plain `float`.

### Simplifications / cleanups

- `slice_plot` / `density_and_slice_plot` check key-unit consistency by comparing `pmd_unit` objects (value-based) instead of symbol strings, and raise `ValueError` instead of a bare `assert`.
- `parse_bunching_str` raises `ValueError` instead of `assert`.
- `pg_units` gained the slice-statistics keys `current` (A) and `density` (C/m).
- `readers.component_str` describes unknown dimensions instead of raising `KeyError`.
- The fieldmesh rectangular plot labels render units via `to_tex()` / safe prefixing (matching the cylindrical plot), and the `Re[...]`/`Im[...]` legend brackets are balanced.
- Stale doctests in `units.py` fixed (including a long-wrong `eV/c` `unitSI` value), and a test now runs the module's doctests so they stay honest.
- Maintainability pass: removed the never-used long-form prefix tables (`PREFIX_FACTOR`/`PREFIX`), a dead constructor bootstrap clause (`or not known_unit` — every import-time unit passes an explicit `unitSI`), and the redundant `__ne__` (Python derives `!=` from `__eq__`). `texlabel` gained the missing `ptp_` formatter (it was listed as an operator prefix but silently fell through to the raw fallback). `mathlabel` with no keys now returns a units-only label (used by the marginal histograms), so the interim `units_tex`/`units_label` helpers folded back into it — `labels.py` exposes exactly two functions, `texlabel` and `mathlabel`.

### Compatibility notes

- `unitDimension`/`unitSI` HDF5 attrs are now always written as float64 (spec-conformant; previously int64 for named units). `unitSymbol` is written as a UTF-8 str attr rather than fixed-length bytes; h5py and openPMD tooling read both, and `read_unit_h5` accepts both.

### Split into a follow-up PR

The same review found several non-unit bugs that are deliberately **not** in this PR, to keep it units-focused: the Genesis2 `.dpa` momentum reconstruction typo (`py * 2` → `py**2`), twiss ignoring particle weights, the statistics standard documenting dimensionally wrong covariance units (`eV/c^2`) and missing `y_bar`/`py_bar` keys, fieldmesh file validation via strippable `assert`s, a dead `units` dict in `genesis4_par_to_data`, and the inverted `average_current` docstring formula.

## 20. Single recursive parser

`from_symbol` and `_parse_single_unit` had grown into near-duplicates: both did the known-unit copy lookup and the sqrt branch, while compound tokenization lived only in the former and power notation/the SI-prefix fallback only in the latter. The duplication had already drifted into a bug: `from_symbol`'s sqrt branch recursed into `from_symbol` (compound-capable), but `_parse_single_unit`'s recursed into *itself* — so `sqrt(kg*m)` parsed while the identical token inside `sqrt(kg*m)*s` raised `Unknown unitSymbol: kg*m`.

`_parse_single_unit` is gone. `from_symbol` is now the single recursive parser:

1. normalize (NFC + homoglyph fold + whitespace, including around `^`);
2. known-unit/alias lookup;
3. tokenize on top-level `*`/`/`; multiple tokens recurse through `from_symbol` and combine;
4. single tokens fall through sqrt → paren group → power (fraction and plain) → SI-prefix fallback, each recursing through `from_symbol` on a strictly shorter substring (so parsing terminates).

Every notation now works uniformly at any recursion depth; `sqrt(kg*m)*s`, `V/sqrt(kg*m)`, and `sqrt(kg*m)^2` all parse and round-trip. Single-token spellings are still preserved in the stored symbol (`m^(1/2)`, `(eV/c)^2`), with redundant parens dropped (`(m)` → `m`).

## Files changed

- `beamphysics/units.py` — fixes for §2, §4–§18 (including `to_tex`, value-based `__eq__`/`__hash__`, `power_unit` distribution, input hardening, sqrt canonicalization, `__pow__` / `compatible_with` / `conversion_factor_to`, the `read_dataset_and_unit_h5` call-site cleanup, round-trip-safe `divide_units`, Unicode homoglyph folding, and parenthesized grouping in the parser).
- `beamphysics/labels.py` — `mathlabel` now uses `pmd_unit.to_tex()` to render unit labels, with the unparseable-string and dimensionless edge cases handled (§12).
- `tests/test_unit.py` — beamphysics-side regression tests for §2–§14, §16–§18.
- `tests/test_labels.py` — new; `mathlabel` rendering tests for §12 (both TeX and non-TeX branches, including the dimensionless and unparseable-string edge cases).
- `tests/test_units_pint.py` — new, independent `pint` cross-check suite (also drops the now-dead `vel/c` entry from its symbol→pint table, §15).
- `docs/examples/units.ipynb` — documents power notation, SI prefixes, the improved `simplify`, canonical-symbol normalization, malformed-input rejection, `to_tex()` + `mathlabel`, value-based equality, and the new `**` / `compatible_with` / `conversion_factor_to` API (§14). Also adds a parenthesized-grouping section (§18) with canonicalization examples, and includes a grouped symbol in the `to_tex()` demo. Cell count 84 → 76 after consolidating overlapping power-notation demos.
- `beamphysics/interfaces/genesis.py` — switch three call sites from the deprecated `unit` alias to `pmd_unit`.
- `beamphysics/plot.py` — labels via `plottable_array_and_units` / `pmd_unit.scaled_symbol`; corrected density/CDF/fieldmesh labels (§19).
- `beamphysics/writers.py`, `beamphysics/readers.py` — unit attrs via `write_unit_h5`; bytes decode; `is_constant_component` fix; graceful unknown dimensions (§19).
- `tests/test_plot_labels.py` — new; plot label tests (scaled_symbol policy, charge-density labels, marginal axis prefixes) and single-particle draw test (§19).
- `pyproject.toml`, `environment.yml` — add `pint` as a test-only dependency.
- `.gitignore` — ignore generated `tests/artifacts/`.

## Test results

```
1796 passed, 1 xpassed, 3 warnings in ~10s
```

(The single xpass is `test_wavefront.py::test_gaussian_plot_fluence[logscale]`, a pre-existing environment-dependent xfail unrelated to this PR.)

Key new tests:

- `test_simplify_examples` — the §3 examples plus `J/C → V`.
- `test_simplify_electric_potential_volt` — locks in the §2 dimension.
- `test_simplify_division_by_compound_round_trips` — §4a regression.
- `test_simplify_dimensionless_never_bare_prefix` — §4b regression.
- `test_simplify_never_breaks_round_trip` — invariant over all named-unit products/quotients.
- `test_parsing_compound_does_not_mutate_named_units` — §5 regression.
- `test_si_prefix_parsing`, `test_bare_prefix_and_junk_rejected`, `test_prefix_does_not_shadow_base_units`, `test_simplify_prefixed_output_round_trips` — §6.
- `test_sqrt_unit_halves_dimension`, `test_sqrt_unit_symbol_round_trips`, `test_sqrt_symbol_whitespace_normalized`, `test_latex_sqrt_form_not_accepted` — §7, §10.
- `test_cov_units_with_prefixed_subkey` — §8 regression.
- `test_ohm_unit_and_alias`, `test_wakefield_unit_strings_parse` — §9.
- `test_whitespace_around_caret_tolerated`, `test_symbol_whitespace_normalized_in_stored_form`, `test_parser_rejects_empty_operands`, `test_negative_unitSI_rejected` — §10.
- `test_power_unit_distributes_over_compound`, `test_simplify_skips_compound_numerator` — §11.
- `test_to_tex_translation`, `test_to_tex_preserves_input_structure` — §12.
- `test_equality_is_value_based_per_standard`, `test_hash_distinguishes_same_dimension_units` — §13.
- `test_pow_operator_matches_power_unit`, `test_compatible_with_is_dimension_only`, `test_conversion_factor_to_round_trips_and_rejects_mismatch`, `test_norm_emit_4d_stored_as_m_squared` — §14.
- `test_divide_by_compound_divisor_round_trips`, `test_divide_with_empty_numerator_symbol` — §16.
- `test_unicode_homoglyphs_normalized` — §17.
- `test_parenthesized_grouping_parses`, `test_parenthesized_group_with_power`, `test_malformed_parens_rejected`, `test_divide_units_emits_parenthesized_divisor` — §18 (plus parenthesized/nested symbols added to the pint cross-check's compound-symbol table).
- `tests/test_labels.py` (new) — `mathlabel` rendering through `to_tex()`, the `{\cdot}` fallback, and the dimensionless non-TeX edge case — §12.

### Independent `pint` cross-check (`tests/test_units_pint.py`)

`pint` is used as an external oracle (test-only; the package never imports it). It verifies, against `pint`'s own dimensional analysis:

- the `DIMENSION` dict (every named dimension) — this is the check that would have caught the §2 `electric_potential` bug;
- every `NAMED_UNITS` entry (dimension **and** SI scale);
- compound-symbol parsing, SI-prefixed symbols, and fractional/`sqrt` powers (e.g. spectral densities like `V/m/Hz^0.5`);
- `simplify()` preserves physical meaning;
- the entire `pg_units` table (all keys, plus operator/`cov_`/field-prefix rules), with a guard that every key has an independent expectation;
- impedance / wakefield units (`Ω`, `Ω/m`, `V/A`, `V/C`, `V/C/m`).

## Acknowledgment

The review, bug fixes (§2, §4–§9), the independent `pint` cross-check suite, the regression tests, and the updated `docs/examples/units.ipynb` were developed in collaboration with **Claude** (Anthropic's Claude Opus 4.8, via Claude Code). It traced the `electric_potential` dimension error, the `simplify` round-trip and `NAMED_UNITS` mutation bugs, the `sqrt_unit` floor-division bug, and the `cov_` key-parsing bug, and proposed the `pint` oracle that anchors the units to an independent reference. A follow-up review pass (Claude Fable 5) found and fixed the two `mathlabel` edge cases (§12), the `divide_units` compound-divisor symbol (§16), and the Unicode homoglyph rejection (§17), and added parenthesized grouping to the symbol grammar (§18).
