### PR TITLE
Small fixes from the units-overhaul review

### DIFF
--- a/beamphysics/fields/analysis.py
+++ b/beamphysics/fields/analysis.py
@@ -1180,7 +1180,7 @@ def plot_maxwell_curl_equations_cartesian(FM, ix=None, iy=None, plot_diff=True):
         +np.real(DyEz - DzEy)[ix, iy, :],
         label=r"$\Re\left[\frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z}\right]$",
     )
-    axs[0, 0].plot(z, +np.real(1j * w * Bx[ix, iy, :]), label=r"$-\Re[i\omega B_x]$")
+    axs[0, 0].plot(z, +np.real(1j * w * Bx[ix, iy, :]), label=r"$\Re[i\omega B_x]$")
     axs[0, 0].set_xlabel("z (m)")
     axs[0, 0].set_ylabel(r"($\vec\nabla\times\vec{E})_x$ $(\text{V/m}^2)$")
     axs[0, 0].legend()
@@ -1207,7 +1207,7 @@ def plot_maxwell_curl_equations_cartesian(FM, ix=None, iy=None, plot_diff=True):
         +np.real(DzEx - DxEz)[ix, iy, :],
         label=r"$\Re\left[\frac{\partial E_x}{\partial z} - \frac{\partial E_z}{\partial x}\right]$",
     )
-    axs[1, 0].plot(z, +np.real(1j * w * By[ix, iy, :]), label=r"$-\Re[i\omega B_y]$")
+    axs[1, 0].plot(z, +np.real(1j * w * By[ix, iy, :]), label=r"$\Re[i\omega B_y]$")
     axs[1, 0].set_xlabel("z (m)")
     axs[1, 0].set_ylabel(r"($\vec\nabla\times\vec{E})_y$ $(\text{V/m}^2)$")
     axs[1, 0].legend()
@@ -1229,7 +1229,7 @@ def plot_maxwell_curl_equations_cartesian(FM, ix=None, iy=None, plot_diff=True):
         +np.real(DxEy - DyEx)[ix, iy, :],
         label=r"$\Re\left[\frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y}\right]$",
     )
-    axs[2, 0].plot(z, +np.real(1j * w * Bz[ix, iy, :]), label=r"$-\Re[i\omega B_z]$")
+    axs[2, 0].plot(z, +np.real(1j * w * Bz[ix, iy, :]), label=r"$\Re[i\omega B_z]$")
     axs[2, 0].set_xlabel("z (m)")
     axs[2, 0].set_ylabel(r"($\vec\nabla\times\vec{E})_z$ $(\text{V/m}^2)$")
     axs[2, 0].legend()
@@ -1336,8 +1336,8 @@ def plot_maxwell_curl_equations_cartesian(FM, ix=None, iy=None, plot_diff=True):
             color="black",
             alpha=0.15,
         )
-        axs[1, 1].set_zorder(ax202.get_zorder() + 1)  # Bring primary axis to the front
-        axs[1, 1].patch.set_visible(False)  # Hide the 'canvas' of the primary axis
+        axs[2, 1].set_zorder(ax212.get_zorder() + 1)  # Bring primary axis to the front
+        axs[2, 1].patch.set_visible(False)  # Hide the 'canvas' of the primary axis
         ax212.set_ylabel(r"$\Delta$ ($\text{V/m}^3$)")
 
     fig.suptitle(rf"Fields evaluated at $x=${x[ix]:0.6f}, $y=${y[iy]:0.6f} meters.")
@@ -1390,8 +1390,8 @@ def solenoid_analysis(z0, Bz0):
     B0 = Bz0.max()
 
     Bz0 = Bz0 / B0
-    BL = np.trapezoid(Bz0, z0)
-    B2L = np.trapezoid(Bz0**2, z0)
+    BL = trapezoid(Bz0, z0)
+    B2L = trapezoid(Bz0**2, z0)
     d = {}
     d["B0"] = B0
     d["int_BL"] = BL * B0

--- a/beamphysics/fields/conversion.py
+++ b/beamphysics/fields/conversion.py
@@ -15,15 +15,18 @@ def fieldmesh_rectangular_to_cylindrically_symmetric_data(fieldmesh):
 
     """
 
-    assert fieldmesh.geometry == "rectangular"
+    if fieldmesh.geometry != "rectangular":
+        raise ValueError(f"Requires rectangular geometry, got: {fieldmesh.geometry}")
 
     # Find central slice x=0, y=0
     ix = np.where(fieldmesh.coord_vec("x") == 0)[0]
-    assert len(ix) == 1
+    if len(ix) != 1:
+        raise ValueError("Grid must contain exactly one x = 0 point")
     ix = ix[0]
 
     iy = np.where(fieldmesh.coord_vec("y") == 0)[0]
-    assert len(iy) == 1
+    if len(iy) != 1:
+        raise ValueError("Grid must contain exactly one y = 0 point")
     iy = iy[0]
 
     # Form components

--- a/beamphysics/fields/expansion.py
+++ b/beamphysics/fields/expansion.py
@@ -272,7 +272,8 @@ def expand_fieldmesh_from_onaxis(
     if not inplace:
         fieldmesh = fieldmesh.copy()
 
-    assert fieldmesh.geometry == "cylindrical"
+    if fieldmesh.geometry != "cylindrical":
+        raise ValueError(f"Requires cylindrical geometry, got: {fieldmesh.geometry}")
 
     has_Ez = "electricField/z" in fieldmesh.components
     has_Bz = "magneticField/z" in fieldmesh.components
@@ -293,7 +294,8 @@ def expand_fieldmesh_from_onaxis(
     frequency = fieldmesh.frequency
 
     # Get real field
-    assert all(np.isreal(fz))
+    if not all(np.isreal(fz)):
+        raise ValueError("On-axis field must be real for expansion")
     fz = np.real(fz)
 
     zvec = fieldmesh.coord_vec("z")

--- a/beamphysics/fields/fieldmesh.py
+++ b/beamphysics/fields/fieldmesh.py
@@ -1170,14 +1170,14 @@ def load_field_data_dict(data_dict, verbose=True):
     # Go through components. Allow aliases
     comp = data["components"] = {}
     for k, v in data_dict["components"].items():
-        if k in component_alias:
-            comp[k] = v
-        elif k in component_from_alias:
+        if k in component_from_alias:
             k = component_from_alias[k]
-            if k in comp:
-                raise ValueError(f"Duplicate component: {k}")
-            comp[k] = v
-        else:
+        elif k not in component_alias:
             raise ValueError(f"Unallowed component: {k}")
+        # Canonical and alias spellings of the same component collide here,
+        # regardless of which order the dict provides them in.
+        if k in comp:
+            raise ValueError(f"Duplicate component: {k}")
+        comp[k] = v
 
     return data

--- a/beamphysics/fields/fieldmesh.py
+++ b/beamphysics/fields/fieldmesh.py
@@ -557,7 +557,7 @@ class FieldMesh:
                 **kwargs,
             )
         elif self.geometry == "rectangular":
-            plot_fieldmesh_rectangular_2d(
+            return plot_fieldmesh_rectangular_2d(
                 self,
                 component=component,
                 time=time,
@@ -1129,14 +1129,17 @@ def load_field_data_h5(h5, verbose=True):
 
             # Check dimensions
             dim = h5[name].attrs["unitDimension"]
-            assert np.all(
-                dim == required_dim
-            ), f"{name} with dimension {required_dim} expected for {name}, found: {dim}"
+            if not np.all(dim == required_dim):
+                raise ValueError(
+                    f"{name}: expected unitDimension {tuple(required_dim)}, "
+                    f"found {tuple(dim)}"
+                )
 
             # Check shape
             s1 = tuple(attrs["gridSize"])
             s2 = cdat.shape
-            assert s1 == s2, f"Expected shape: {s1} != found shape: {s2}"
+            if s1 != s2:
+                raise ValueError(f"{name}: expected shape {s1}, found {s2}")
 
             # Static fields should be real
             if attrs["harmonic"] == 0:
@@ -1171,7 +1174,8 @@ def load_field_data_dict(data_dict, verbose=True):
             comp[k] = v
         elif k in component_from_alias:
             k = component_from_alias[k]
-            assert k not in data
+            if k in comp:
+                raise ValueError(f"Duplicate component: {k}")
             comp[k] = v
         else:
             raise ValueError(f"Unallowed component: {k}")

--- a/beamphysics/interfaces/ansys.py
+++ b/beamphysics/interfaces/ansys.py
@@ -73,7 +73,7 @@ def read_ansys_ascii_3d_fields(efile, hfile, frequency=0):
     components = {}
     for k in components1:
         components[f"electricField/{k}"] = components1[k]
-    for k in components1:
+    for k in components2:
         components[f"magneticField/{k}"] = components2[k] * mu_0
 
     attrs = attrs1

--- a/beamphysics/interfaces/astra.py
+++ b/beamphysics/interfaces/astra.py
@@ -271,7 +271,7 @@ def astra_1d_fieldmap_data(fm):
         iangle = np.unique(np.mod(np.angle(fz), np.pi))
 
         # Make sure there is only one
-        assert len(iangle) == 1, print(iangle)
+        assert len(iangle) == 1, f"Expected exactly one angle, found: {iangle}"
         iangle = iangle[0]
 
         if iangle != 0:

--- a/beamphysics/interfaces/astra.py
+++ b/beamphysics/interfaces/astra.py
@@ -466,7 +466,10 @@ def write_astra_3d_fieldmaps(fieldmesh_object, common_filePath):
         base[0:2] == "3D" or base[3:5] == "3D"
     ), "The base filename must begin with 3D or have 3D starting at the fourth character, according to Astra"
 
-    assert fieldmesh_object.geometry == "rectangular"
+    if fieldmesh_object.geometry != "rectangular":
+        raise ValueError(
+            f"Requires rectangular geometry, got: {fieldmesh_object.geometry}"
+        )
 
     nx, ny, nz = fieldmesh_object.shape
 

--- a/beamphysics/interfaces/cst.py
+++ b/beamphysics/interfaces/cst.py
@@ -35,6 +35,7 @@ def get_scale(unit):
         return 1
     elif unit == "[A/m]":
         return mu0
+    raise ValueError(f"Unknown unit in CST file: {unit!r}")
 
 
 def get_vec(x):
@@ -185,6 +186,9 @@ def read_cst_ascii_3d_field(filePath, n_header=2):
         Fx = dat[:, 3].reshape(shape, order="F") * get_scale(units[3])
         Fy = dat[:, 4].reshape(shape, order="F") * get_scale(units[4])
         Fz = dat[:, 5].reshape(shape, order="F") * get_scale(units[5])
+
+    else:
+        raise ValueError(f"Expected 6 or 9 columns in CST file, found {len(columns)}")
 
     attrs = {}
     attrs["gridOriginOffset"] = (xmin, ymin, zmin)

--- a/beamphysics/interfaces/cst.py
+++ b/beamphysics/interfaces/cst.py
@@ -270,9 +270,12 @@ def read_cst_ascii_3d_complex_fields(efile, hfile, frequency, harmonic=1):
     e_attrs, e_components = read_cst_ascii_3d_field(efile)
     b_attrs, b_components = read_cst_ascii_3d_field(hfile)
 
-    assert e_attrs["gridOriginOffset"] == b_attrs["gridOriginOffset"]
-    assert e_attrs["gridSpacing"] == b_attrs["gridSpacing"]
-    assert e_attrs["gridSize"] == b_attrs["gridSize"]
+    for attr in ("gridOriginOffset", "gridSpacing", "gridSize"):
+        if e_attrs[attr] != b_attrs[attr]:
+            raise ValueError(
+                f"E and B field grids disagree on {attr}: "
+                f"{e_attrs[attr]} != {b_attrs[attr]}"
+            )
 
     components = {**e_components, **b_components}
 

--- a/beamphysics/interfaces/elegant.py
+++ b/beamphysics/interfaces/elegant.py
@@ -82,7 +82,7 @@ def elegant_h5_to_data(h5, group="page1", species="electron"):
 
     Elegant h5 has datasets:
 
-    x, xp, y, xp, p=beta*gamma, t
+    x, xp, y, yp, p=beta*gamma, t
     m,  1,   m, 1, 1, s
 
     Momentum are reconstructed as:
@@ -215,7 +215,7 @@ def elegant_to_data(
 
     Columns in the file should be:
 
-    x, xp, y, xp, p=beta*gamma, t
+    x, xp, y, yp, p=beta*gamma, t
     m,  1,   m, 1, 1, s
 
     Momentum are reconstructed as:

--- a/beamphysics/interfaces/genesis.py
+++ b/beamphysics/interfaces/genesis.py
@@ -184,13 +184,15 @@ def genesis2_dpa_to_data(dpa, *, xlamds, current, zsep=1, species="electron"):
 
     """
 
-    assert species == "electron"
+    if species != "electron":
+        raise ValueError(f"Only electron is supported, got: {species}")
     mc2 = mec2
 
     dz = xlamds * zsep
 
     nslice, dims, n1 = dpa.shape  # n1 particles in a single slice
-    assert dims == 6
+    if dims != 6:
+        raise ValueError(f".dpa data must have 6 phase-space dimensions, found {dims}")
     n_particle = n1 * nslice
 
     gamma = dpa[:, 0, :].flatten()
@@ -496,7 +498,8 @@ def genesis4_par_to_data(h5, species="electron", smear=True):
 
     params = {}
     for k in scalars:
-        assert len(h5[k]) == 1
+        if len(h5[k]) != 1:
+            raise ValueError(f"Expected a single value for {k}, found {len(h5[k])}")
         params[k] = h5[k][0]
 
     # Useful local variables
@@ -520,7 +523,8 @@ def genesis4_par_to_data(h5, species="electron", smear=True):
             continue
 
         current = g["current"][:]  # I * s_spacing/c = Q
-        assert len(current) == 1
+        if len(current) != 1:
+            raise ValueError(f"Expected a single current value, found {len(current)}")
         # Skip zero current slices. These usually have nans in the particle data.
         if current == 0:
             i0 += sample

--- a/beamphysics/interfaces/genesis.py
+++ b/beamphysics/interfaces/genesis.py
@@ -199,7 +199,7 @@ def genesis2_dpa_to_data(dpa, *, xlamds, current, zsep=1, species="electron"):
     y = dpa[:, 3, :].flatten()
     px = dpa[:, 4, :].flatten() * mc2
     py = dpa[:, 5, :].flatten() * mc2
-    pz = np.sqrt((gamma**2 - 1) * mc2**2 - px**2 - py * 2)
+    pz = np.sqrt((gamma**2 - 1) * mc2**2 - px**2 - py**2)
 
     i0 = np.arange(nslice)
     i_slice = np.repeat(i0[:, np.newaxis], n1, axis=1).flatten()
@@ -495,12 +495,9 @@ def genesis4_par_to_data(h5, species="electron", smear=True):
     ]
 
     params = {}
-    units = {}
     for k in scalars:
         assert len(h5[k]) == 1
         params[k] = h5[k][0]
-        if "unit" in h5[k].attrs:
-            units[k] = h5[k].attrs["unit"].decode("utf-8")
 
     # Useful local variables
     ds_slice = params["slicelength"]  # single slice length

--- a/beamphysics/interfaces/gpt.py
+++ b/beamphysics/interfaces/gpt.py
@@ -61,7 +61,7 @@ def write_gpt(particle_group, outfile, asci2gdf_bin=None, verbose=False):
         run_asci2gdf(outfile, asci2gdf_bin)
     else:
         print(
-            f"ASCII particles written. Convert to GDF using: asci2df -o particles.gdf {outfile}"
+            f"ASCII particles written. Convert to GDF using: asci2gdf -o particles.gdf {outfile}"
         )
 
 
@@ -137,7 +137,6 @@ def write_gpt_1d_fieldmap(fm, outfile, asci2gdf_bin=None, verbose=False):
             dat["Bz"] = np.real(fm["Bz"][0, 0, :])
         elif fm.is_pure_electric:
             keys = ["Z", "Ez"]
-            dat["Er"] = np.real(fm["Er"][0, 0, :])
             dat["Ez"] = np.real(fm["Ez"][0, 0, :])
         else:
             raise ValueError("Mixed static field TODO")
@@ -166,7 +165,7 @@ def write_gpt_1d_fieldmap(fm, outfile, asci2gdf_bin=None, verbose=False):
         run_asci2gdf(outfile, asci2gdf_bin, verbose=verbose)
     elif verbose:
         print(
-            f"ASCII field data written. Convert to GDF using: asci2df -o field.gdf {outfile}"
+            f"ASCII field data written. Convert to GDF using: asci2gdf -o field.gdf {outfile}"
         )
 
     return outfile
@@ -227,7 +226,7 @@ def write_gpt_2d_fieldmap(fm, outfile, asci2gdf_bin=None, verbose=False):
 
     elif verbose:
         print(
-            f"ASCII field data written. Convert to GDF using: asci2df -o field.gdf {outfile}"
+            f"ASCII field data written. Convert to GDF using: asci2gdf -o field.gdf {outfile}"
         )
 
     return outfile
@@ -285,7 +284,7 @@ def write_gpt_3d_fieldmap(fm, outfile, asci2gdf_bin=None, verbose=False):
         run_asci2gdf(outfile, asci2gdf_bin, verbose=verbose)
     elif verbose:
         print(
-            f"ASCII field data written. Convert to GDF using: asci2df -o field.gdf {outfile}"
+            f"ASCII field data written. Convert to GDF using: asci2gdf -o field.gdf {outfile}"
         )
 
     return outfile

--- a/beamphysics/interfaces/impact.py
+++ b/beamphysics/interfaces/impact.py
@@ -22,7 +22,7 @@ def parse_impact_particles(
 
     Impact-T input/output particles distribions are ASCII files with columns:
     x (m)
-    GBy = gamma*beta_x (dimensionless)
+    GBx = gamma*beta_x (dimensionless)
     y (m)
     GBy = gamma*beta_y (dimensionless)
     z (m)
@@ -194,8 +194,9 @@ def write_impact(
         # Informational
         # output['Temission_mean'] = tout.mean()
 
-        # pz
-        pz = particle_group["pz"]
+        # pz (copy: the small-momentum shift below must not modify the
+        # caller's ParticleGroup)
+        pz = np.array(particle_group["pz"])
         # check for zero pz
         assert np.all(pz > 0), "pz must be positive"
 
@@ -466,10 +467,10 @@ def create_fourier_data(field_mesh, component, zmirror=False, n_coef=None):
 
     """
 
-    ir = np.where(field_mesh.r == 0)
+    ir = np.where(field_mesh.r == 0)[0]
     if len(ir) != 1:
         raise ValueError("No r=0 found")
-    ir = ir[0][0]
+    ir = ir[0]
 
     z0 = field_mesh.coord_vec("z")
 

--- a/beamphysics/interfaces/impact.py
+++ b/beamphysics/interfaces/impact.py
@@ -612,7 +612,8 @@ def create_impact_solrf_fieldmap_derivatives(
         zmax: float
 
     """
-    assert field_mesh.geometry == "cylindrical"
+    if field_mesh.geometry != "cylindrical":
+        raise ValueError(f"Requires cylindrical geometry, got: {field_mesh.geometry}")
     if method != "spline":
         raise NotImplementedError(f"Unknown method '{method}', must be 'spline'")
 
@@ -630,7 +631,8 @@ def create_impact_solrf_fieldmap_derivatives(
         fz = field_mesh[component][0, 0, :]
 
         fz = np.real_if_close(fz)
-        assert all(np.imag(fz) == 0)
+        if not all(np.imag(fz) == 0):
+            raise ValueError(f"On-axis {component} field must be real")
 
         field[component] = {
             "z0": 0,  # Force

--- a/beamphysics/interfaces/litrack.py
+++ b/beamphysics/interfaces/litrack.py
@@ -26,7 +26,8 @@ def write_litrack(particle_group, outfile="litrack.zd", p0c=None, verbose=False)
 
     P = particle_group  # convenience
 
-    assert P.species == "electron"  # TODO: add more species
+    if P.species != "electron":  # TODO: add more species
+        raise ValueError(f"Only electron is supported, got: {P.species}")
 
     assert np.all(P.weight > 0), "ParticleGroup.weight must be > 0"
 

--- a/beamphysics/interfaces/lucretia.py
+++ b/beamphysics/interfaces/lucretia.py
@@ -192,8 +192,10 @@ def write_lucretia(
         stop_ix = np.zeros(Np)
     else:
         if len(stop_ix) != Np:
-            print("Error: Length of stop_ix must equal to # particles !!")
-        return
+            raise ValueError(
+                f"Length of stop_ix ({len(stop_ix)}) must equal the number "
+                f"of particles ({Np})"
+            )
 
     # Form the lowest level of field structure
     l1 = np.array([x_luc, px_luc, y_luc, py_luc, z_luc, ptot])

--- a/beamphysics/interfaces/opal.py
+++ b/beamphysics/interfaces/opal.py
@@ -75,7 +75,8 @@ def opal_to_data(h5):
     rref = D["RefPartR"]
 
     n = len(ptypes)
-    assert all(h5["ptype"][:] == 0)
+    if not all(h5["ptype"][:] == 0):
+        raise ValueError("Only ptype == 0 (electron) is supported")
     species = "electron"
     status = 1
     data = {

--- a/beamphysics/interfaces/superfish.py
+++ b/beamphysics/interfaces/superfish.py
@@ -79,7 +79,7 @@ def fish_complex_to_real_fields(fm, verbose=False):
     iangle = np.unique(np.mod(np.angle(Ez), np.pi))
 
     # Make sure there is only one
-    assert len(iangle) == 1, print(iangle)
+    assert len(iangle) == 1, f"Expected exactly one angle, found: {iangle}"
     iangle = iangle[0]
 
     if iangle != 0:

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -2154,7 +2154,10 @@ def _scalar_maybe_from_array(value):
     if np.isscalar(value):
         return value
 
-    assert len(value) == 1
+    if len(value) != 1:
+        raise ValueError(
+            f"Expected a scalar or length-1 array, got length {len(value)}"
+        )
     return value[0]
 
 

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -401,7 +401,7 @@ class ParticleGroup:
 
     @property
     def n_dead(self):
-        """Number of alive particles, defined by status != 1"""
+        """Number of dead particles, defined by status != 1"""
         return self.n_particle - self.n_alive
 
     def units(self, key: str) -> pmd_unit:
@@ -766,7 +766,7 @@ class ParticleGroup:
 
     @property
     def norm_emit_y(self):
-        """Normalized emittance in the x plane"""
+        """Normalized emittance in the y plane"""
         return norm_emit_calc(self, planes=["y"])
 
     @property
@@ -799,7 +799,7 @@ class ParticleGroup:
         """
 
         return matched_particles(
-            self, beta=beta, alpha=alpha, plane=plane, inplace=inplace
+            self, beta=beta, alpha=alpha, plane=plane, p0c=p0c, inplace=inplace
         )
 
     @property
@@ -822,7 +822,7 @@ class ParticleGroup:
     def average_current(self):
         """
         Simple average `current = charge / dt` in [A], with `dt =  (max_t - min_t)`
-        If particles are in $t$ coordinates, will try` dt = (max_z - min_z)*c_light*beta_z`
+        If particles are in $t$ coordinates, will try `dt = (max_z - min_z) / (c_light * beta_z)`
         """
         dt = np.ptp(self.t)  # ptp 'peak to peak' is max - min
         if dt == 0:
@@ -1024,7 +1024,7 @@ class ParticleGroup:
         """
         Drifts all particles to the same t.
 
-        If no z is given, particles will be drifted to the average t
+        If no t is given, particles will be drifted to the average t
         """
         if t is None:
             t = self.avg("t")
@@ -1832,9 +1832,18 @@ class ParticleGroup:
         return True if item in self._data else False
 
     def __eq__(self, other):
-        """Check equality of internal data"""
+        """Check equality of species and internal data"""
         if isinstance(other, ParticleGroup):
-            for key in ["x", "px", "y", "py", "z", "pz", "t", "status", "weight", "id"]:
+            if self.species != other.species:
+                return False
+            # Only compare ids that already exist: accessing self["id"] would
+            # otherwise *assign* fresh ids to both operands as a side effect.
+            if ("id" in self._data) != ("id" in other._data):
+                return False
+            keys = ["x", "px", "y", "py", "z", "pz", "t", "status", "weight"]
+            if "id" in self._data:
+                keys.append("id")
+            for key in keys:
                 if not np.allclose(self[key], other[key]):
                     return False
             return True
@@ -1935,9 +1944,9 @@ class ParticleGroup:
         xc : float
             Center of rotation, x coordinate. Default to zero
         yc : float
-            Center of rotation, x coordinate. Default to zero
+            Center of rotation, y coordinate. Default to zero
         zc : float
-            Center of rotation, x coordinate. Default to zero
+            Center of rotation, z coordinate. Default to zero
 
         Notes
         -----

--- a/beamphysics/plot.py
+++ b/beamphysics/plot.py
@@ -156,7 +156,7 @@ def slice_plot(
         raise ValueError(f"Incompatible units: {[u.unitSymbol for u in ulist]}")
     uy = u0.unitSymbol
 
-    ymin = max([slice_dat[k].min() for k in keys])
+    ymin = min([slice_dat[k].min() for k in keys])
     ymax = max([slice_dat[k].max() for k in keys])
 
     _, f2, uy, ymin, ymax = plottable_array_and_units(
@@ -1024,6 +1024,9 @@ def plot_fieldmesh_rectangular_2d(
         orientation="vertical",
         label=llabel,
     )
+
+    if return_figure:
+        return fig
 
 
 def plot_1d_density(

--- a/beamphysics/plot.py
+++ b/beamphysics/plot.py
@@ -793,6 +793,8 @@ def plot_fieldmesh_rectangular_1d(
 
     if not axes:
         fig, axes = plt.subplots(**kwargs)
+    else:
+        fig = axes.get_figure()
 
     # Use recursion to plot multiple field components
     if isinstance(field_component, list):
@@ -906,6 +908,8 @@ def plot_fieldmesh_rectangular_2d(
 
     if not axes:
         fig, axes = plt.subplots(**kwargs)
+    else:
+        fig = axes.get_figure()
 
     if not cmap:
         cmap = CMAP1

--- a/beamphysics/plot.py
+++ b/beamphysics/plot.py
@@ -604,7 +604,8 @@ def plot_fieldmesh_cylindrical_2d(
 
     """
 
-    assert fm.geometry == "cylindrical"
+    if fm.geometry != "cylindrical":
+        raise ValueError(f"Requires cylindrical geometry, got: {fm.geometry}")
 
     if mirror not in (None, "r"):
         raise ValueError("mirror must be None or 'r'")
@@ -890,7 +891,8 @@ def plot_fieldmesh_rectangular_2d(
 
     """
 
-    assert fm.geometry == "rectangular"
+    if fm.geometry != "rectangular":
+        raise ValueError(f"Requires rectangular geometry, got: {fm.geometry}")
 
     valid_coordinates = set(fm.axis_labels)
     coordinate_value = None

--- a/beamphysics/standards/statistics.py
+++ b/beamphysics/standards/statistics.py
@@ -63,7 +63,7 @@ p energy kinetic_energy xp yp higher_order_energy
 r theta pr ptheta
 Lz
 gamma beta beta_x beta_y beta_z
-x_bar px_bar Jx Jy
+x_bar px_bar y_bar py_bar Jx Jy
 """.split()
 
 # Operators and their properties for computed statistics
@@ -260,7 +260,7 @@ def validate_against_particlegroup(standard: Dict[str, Any]) -> List[str]:
         # Try to access the attribute
         try:
             value = P[label]
-        except (AttributeError, KeyError, Exception) as e:
+        except Exception as e:
             warnings.append(f"Label '{label}' not accessible in ParticleGroup: {e}")
             continue
 
@@ -419,9 +419,10 @@ def generate_markdown(standard: Dict[str, Any]) -> str:
             if units:
                 try:
                     u = pmd_unit.from_symbol(units)
-                    lines.append(f"**unitSI:** `{u.unitSI}`")
+                    lines.append(f"**unitSI:** `{u.unitSI:g}`")
                     lines.append("")
-                    lines.append(f"**unitDimension:** `{u.unitDimension}`")
+                    dim = ", ".join(f"{d:g}" for d in u.unitDimension)
+                    lines.append(f"**unitDimension:** `({dim})`")
                     lines.append("")
                 except (ValueError, KeyError):
                     pass  # Skip if unit cannot be parsed
@@ -527,19 +528,9 @@ def get_category(
 
 
 def _multiply_units(unit1: str, unit2: str) -> str:
-    """Multiply two unit strings together."""
-    if unit1 == "1" and unit2 == "1":
-        return "1"
-    if unit1 == "1":
-        return unit2
-    if unit2 == "1":
-        return unit1
-
-    # Handle common simplifications
-    if unit1 == unit2:
-        return f"{unit1}^2"
-
-    return f"{unit1}*{unit2}"
+    """Multiply two unit strings, matching the units pg_units computes for
+    covariance keys (identity handling and round-trip-safe symbols included)."""
+    return (pmd_unit(unit1) * pmd_unit(unit2)).unitSymbol
 
 
 def _generate_computed_statistics_list(base_stats: Dict[str, Dict]) -> List[Dict]:

--- a/beamphysics/standards/statistics.py
+++ b/beamphysics/standards/statistics.py
@@ -257,10 +257,13 @@ def validate_against_particlegroup(standard: Dict[str, Any]) -> List[str]:
         if label == "bunching":
             label = "bunching_1.23e-4"
 
-        # Try to access the attribute
+        # Access the attribute. Only the exceptions that ParticleGroup
+        # raises to signal "this is not a supported key" are treated as a
+        # validation finding; any other exception is a real bug in the
+        # lookup and is allowed to propagate rather than be hidden here.
         try:
             value = P[label]
-        except Exception as e:
+        except (AttributeError, KeyError, ValueError) as e:
             warnings.append(f"Label '{label}' not accessible in ParticleGroup: {e}")
             continue
 

--- a/beamphysics/statistics.py
+++ b/beamphysics/statistics.py
@@ -527,7 +527,7 @@ def resample_particles(particle_group, n=0, equal_weights=False):
         weight = np.full(n, particle_group.charge / n)
 
     else:
-        assert n == n_old
+        assert n == n_old, f"Internal error: expected n == n_old, got {n} != {n_old}"
         ixlist = np.random.choice(n_old, n, replace=False)
         weight = weight[ixlist]  # just scramble
 

--- a/beamphysics/statistics.py
+++ b/beamphysics/statistics.py
@@ -115,7 +115,7 @@ def matched_particles(
 ):
     """
     Perfoms simple Twiss 'matching' by applying a linear transformation to
-        x, px if plane == 'x', or x, py if plane == 'y'
+        x, px if plane == 'x', or y, py if plane == 'y'
 
     Returns a new ParticleGroup
 
@@ -243,16 +243,16 @@ def particle_twiss_dispersion(particle_group, plane="x", fraction=1, p0c=None):
 
     x = P[plane]
     xp = P["p" + plane] / p0c
-    delta = P["p"] / P["mean_p"]  # - 1
+    delta = P["p"] / p0c  # - 1
 
-    # Form covariance matrix
-    np.cov([x, xp, delta], aweights=P.weight)
+    # Form weighted covariance matrix
+    sigma = np.cov([x, xp, delta], aweights=P.weight)
 
     # Actual calc
-    twiss = twiss_dispersion_calc(np.cov([x, xp, delta]))
+    twiss = twiss_dispersion_calc(sigma)
 
     # Add norm
-    twiss["norm_emit"] = twiss["emit"] * P["mean_p"] / P.mass
+    twiss["norm_emit"] = twiss["emit"] * p0c / P.mass
 
     # Add suffix
     out = {}
@@ -444,7 +444,6 @@ def slice_statistics(particle_group, keys=["mean_z"], n_slice=40, slice_key=None
     normal_keys = set()
 
     for k in keys:
-        sdat[k] = np.empty(n_slice)
         if k.startswith("twiss"):
             if k == "twiss" or k == "twiss_xy":
                 twiss_planes.add("x")
@@ -454,6 +453,7 @@ def slice_statistics(particle_group, keys=["mean_z"], n_slice=40, slice_key=None
                 assert plane in ("x", "y")
                 twiss_planes.add(plane)
         else:
+            sdat[k] = np.empty(n_slice)
             normal_keys.add(k)
 
     twiss_plane = "".join(twiss_planes)  # flatten

--- a/beamphysics/statistics.py
+++ b/beamphysics/statistics.py
@@ -114,7 +114,7 @@ def matched_particles(
     particle_group, beta=None, alpha=None, plane="x", p0c=None, inplace=False
 ):
     """
-    Perfoms simple Twiss 'matching' by applying a linear transformation to
+    Performs simple Twiss 'matching' by applying a linear transformation to
         x, px if plane == 'x', or y, py if plane == 'y'
 
     Returns a new ParticleGroup

--- a/beamphysics/testing.py
+++ b/beamphysics/testing.py
@@ -103,7 +103,9 @@ def assert_pg_close(pg_test, pg_ref, atol=1e-7, rtol=0, err_msg=""):
     err_msg : str, optional
         Error message to emit when failed, by default ""
     """
-    assert pg_test.species == pg_ref.species
+    assert (
+        pg_test.species == pg_ref.species
+    ), f"species differ: {pg_test.species} != {pg_ref.species}"
     for key in ["x", "px", "y", "py", "z", "pz", "t"]:
         np.testing.assert_allclose(
             pg_ref[key], pg_test[key], rtol=rtol, atol=atol, err_msg=err_msg

--- a/beamphysics/wakefields/base.py
+++ b/beamphysics/wakefields/base.py
@@ -141,7 +141,7 @@ class WakefieldBase(ABC):
         Returns
         -------
         integrated_wake : np.ndarray
-            Integrated longitudinal wakefield [V].
+            Integrated longitudinal wakefield [V/m].
         """
         from scipy.signal import correlate
 

--- a/beamphysics/wakefields/pseudomode.py
+++ b/beamphysics/wakefields/pseudomode.py
@@ -333,7 +333,7 @@ class PseudomodeWakefield(WakefieldBase):
                 zi = z_sorted[i]
                 qi = weight_sorted[i]
 
-                # Kick from trailing particles
+                # Kick from the particles already accumulated in b (those ahead)
                 delta_E[i] -= np.imag(c * np.exp(s * zi) * b)
 
                 # Add this particle to accumulator

--- a/beamphysics/wavefront/wavefront.py
+++ b/beamphysics/wavefront/wavefront.py
@@ -1551,7 +1551,7 @@ class Wavefront(WavefrontBase):
                 dfl, param = load_genesis4_fields(h5)
 
         elif isinstance(file, h5py.Group):
-            dfl, param = load_genesis4_fields(h5)
+            dfl, param = load_genesis4_fields(file)
         else:
             raise ValueError(f"{file=} must be a str, pathlib.Path, or h5py.Group")
 

--- a/tests/test_fieldmesh.py
+++ b/tests/test_fieldmesh.py
@@ -66,3 +66,28 @@ def test_fieldmesh_limits(fm_dipole_corrector):
     FM.zmin = 100
     L3 = FM.zmax - FM.zmin
     assert L1 == L3
+
+
+def test_duplicate_component_alias_rejected():
+    """A data dict containing both a canonical component name and its alias
+    must raise, not silently overwrite one with the other."""
+    from beamphysics.fields.fieldmesh import load_field_data_dict
+
+    arr = np.ones((2, 2, 2))
+    attrs = {
+        "eleAnchorPt": "beginning",
+        "gridGeometry": "rectangular",
+        "axisLabels": ("x", "y", "z"),
+        "gridLowerBound": (0, 0, 0),
+        "gridOriginOffset": (0.0, 0.0, 0.0),
+        "gridSpacing": (0.01, 0.01, 0.01),
+        "gridSize": (2, 2, 2),
+        "harmonic": 0,
+        "fundamentalFrequency": 0,
+    }
+    data = {
+        "attrs": attrs,
+        "components": {"electricField/z": arr, "Ez": 2 * arr},
+    }
+    with pytest.raises(ValueError, match="Duplicate component"):
+        load_field_data_dict(data, verbose=False)

--- a/tests/test_fieldmesh.py
+++ b/tests/test_fieldmesh.py
@@ -68,9 +68,17 @@ def test_fieldmesh_limits(fm_dipole_corrector):
     assert L1 == L3
 
 
-def test_duplicate_component_alias_rejected():
+@pytest.mark.parametrize(
+    "component_keys",
+    [
+        ("electricField/z", "Ez"),  # canonical first
+        ("Ez", "electricField/z"),  # alias first
+    ],
+)
+def test_duplicate_component_alias_rejected(component_keys):
     """A data dict containing both a canonical component name and its alias
-    must raise, not silently overwrite one with the other."""
+    must raise, not silently overwrite one with the other — regardless of
+    dict insertion order."""
     from beamphysics.fields.fieldmesh import load_field_data_dict
 
     arr = np.ones((2, 2, 2))
@@ -85,9 +93,10 @@ def test_duplicate_component_alias_rejected():
         "harmonic": 0,
         "fundamentalFrequency": 0,
     }
+    k1, k2 = component_keys
     data = {
         "attrs": attrs,
-        "components": {"electricField/z": arr, "Ez": 2 * arr},
+        "components": {k1: arr, k2: 2 * arr},
     }
     with pytest.raises(ValueError, match="Duplicate component"):
         load_field_data_dict(data, verbose=False)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from beamphysics import ParticleGroup
+
+
+def make_particle_group(pz):
+    n = len(pz)
+    data = {
+        "x": np.zeros(n),
+        "px": np.zeros(n),
+        "y": np.zeros(n),
+        "py": np.zeros(n),
+        "z": np.zeros(n),
+        "pz": np.array(pz, dtype=float),
+        "t": np.zeros(n),
+        "status": np.ones(n, dtype=int),
+        "weight": np.full(n, 1e-12),
+        "species": "electron",
+    }
+    return ParticleGroup(data=data)
+
+
+def test_write_impact_does_not_mutate_caller(tmp_path):
+    """The cathode-start small-pz shift must act on a copy, not the
+    caller's internal pz array."""
+    from beamphysics.interfaces.impact import write_impact
+
+    P = make_particle_group([5.0, 1e6, 1e6])
+    pz_before = P.pz.copy()
+    write_impact(P, tmp_path / "impact.in", cathode_kinetic_energy_ref=1.0)
+    np.testing.assert_array_equal(P.pz, pz_before)
+
+
+def test_write_lucretia_with_stop_ix(tmp_path):
+    """A valid stop_ix array must produce a file; a wrong-length one must
+    raise instead of silently writing nothing."""
+    from beamphysics.interfaces.lucretia import write_lucretia
+
+    P = make_particle_group([1e6, 2e6, 3e6])
+    outfile = tmp_path / "beam.mat"
+    write_lucretia(P, str(outfile), stop_ix=[0, 0, 0], verbose=False)
+    assert outfile.exists()
+
+    with pytest.raises(ValueError, match="stop_ix"):
+        write_lucretia(P, str(tmp_path / "bad.mat"), stop_ix=[0, 0], verbose=False)
+
+
+def test_cst_get_scale_rejects_unknown_units():
+    from beamphysics.interfaces.cst import get_scale
+
+    assert get_scale("[mm]") == 1e-3
+    assert get_scale("[V/m]") == 1
+    with pytest.raises(ValueError, match="Unknown unit"):
+        get_scale("[cm]")

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,48 +1,85 @@
 from __future__ import annotations
 
+import pytest
+
 from beamphysics.labels import mathlabel
 from beamphysics.units import pmd_unit, sqrt_unit
 
 
-def test_mathlabel_renders_pmd_unit_via_to_tex() -> None:
-    assert mathlabel("x", units=pmd_unit("eV/c")) == r"$x~(\mathrm{eV}/\mathrm{c})$"
-    assert (
-        mathlabel("x_bar", units=sqrt_unit(pmd_unit("m")))
-        == r"$\overline{x}~(\sqrt{\mathrm{m}})$"
-    )
-
-
-def test_mathlabel_parses_unit_strings() -> None:
-    # A str that parses as a unit symbol renders through to_tex.
-    assert mathlabel("x", units="kg*m/s") == (
-        r"$x~(\mathrm{kg}{\cdot}\mathrm{m}/\mathrm{s})$"
-    )
-
-
-def test_mathlabel_unparseable_string_fallback_keeps_cdot() -> None:
-    # The fallback for strings that are not valid unit symbols still
-    # replaces "*" with {\cdot}.
-    label = mathlabel("x", units="foo*bar")
-    assert r"{\cdot}" in label
-    assert "*" not in label
-
-
-def test_mathlabel_dimensionless_unit_adds_no_parens() -> None:
-    # A dimensionless unit (empty symbol) adds no "()" annotation in either
-    # branch. (A pmd_unit is always truthy, so the check must use its str.)
-    dimensionless = pmd_unit("1")
-    assert mathlabel("x", units=pmd_unit(""), tex=False) == "x"
-    assert mathlabel("x", units=pmd_unit(""), tex=True) == "$x$"
-    # pmd_unit("1") stores the symbol "1" and is annotated as such.
-    assert mathlabel("x", units=dimensionless, tex=False) == "x (1)"
-
-
-def test_mathlabel_no_units() -> None:
-    assert mathlabel("x", tex=False) == "x"
-    assert mathlabel("x", units=None, tex=True) == "$x$"
-    assert mathlabel("x", units="", tex=True) == "$x$"
-
-
-def test_mathlabel_non_tex_uses_symbol() -> None:
-    assert mathlabel("x", units=pmd_unit("eV/c"), tex=False) == "x (eV/c)"
-    assert mathlabel("x", "y", units="µC", tex=False) == "x, y (µC)"
+@pytest.mark.parametrize(
+    ("keys", "units", "tex", "expected"),
+    [
+        # A pmd_unit renders through to_tex.
+        pytest.param(
+            ("x",),
+            pmd_unit("eV/c"),
+            True,
+            r"$x~(\mathrm{eV}/\mathrm{c})$",
+            id="pmd_unit-compound",
+        ),
+        pytest.param(
+            ("x_bar",),
+            sqrt_unit(pmd_unit("m")),
+            True,
+            r"$\overline{x}~(\sqrt{\mathrm{m}})$",
+            id="pmd_unit-sqrt",
+        ),
+        # A str that parses as a unit symbol renders the same way.
+        pytest.param(
+            ("x",),
+            "kg*m/s",
+            True,
+            r"$x~(\mathrm{kg}{\cdot}\mathrm{m}/\mathrm{s})$",
+            id="str-parses",
+        ),
+        # A str that is not a unit symbol falls back to mathrm, * -> cdot.
+        pytest.param(
+            ("x",),
+            "foo*bar",
+            True,
+            r"$x~(\mathrm{ foo{\cdot}bar })$",
+            id="str-fallback-cdot",
+        ),
+        # Multiple keys (the docstring example).
+        pytest.param(
+            ("x_bar", "sigma_x"),
+            "µC",
+            True,
+            r"$\overline{x}, \sigma_{ x }~(\mathrm{µC})$",
+            id="multiple-keys",
+        ),
+        # A dimensionless unit (empty symbol) adds no "()" in either branch;
+        # pmd_unit("1") stores the symbol "1" and is annotated as such.
+        pytest.param(("x",), pmd_unit(""), True, "$x$", id="dimensionless-tex"),
+        pytest.param(("x",), pmd_unit(""), False, "x", id="dimensionless-plain"),
+        pytest.param(("x",), pmd_unit("1"), False, "x (1)", id="unity-plain"),
+        # No units.
+        pytest.param(("x",), None, True, "$x$", id="no-units-tex"),
+        pytest.param(("x",), None, False, "x", id="no-units-plain"),
+        pytest.param(("x",), "", True, "$x$", id="empty-units-tex"),
+        # tex=False uses the plain symbol.
+        pytest.param(("x",), pmd_unit("eV/c"), False, "x (eV/c)", id="plain-pmd_unit"),
+        pytest.param(("x", "y"), "µC", False, "x, y (µC)", id="plain-two-keys"),
+        # No keys: a units-only label, as used by the marginal histograms.
+        pytest.param((), "A", True, r"$\mathrm{A}$", id="units-only"),
+        pytest.param(
+            (),
+            "C/(eV/c)",
+            True,
+            r"$\mathrm{C}/(\mathrm{eV}/\mathrm{c})$",
+            id="units-only-grouped",
+        ),
+        pytest.param(
+            (),
+            "foo*bar",
+            True,
+            r"$\mathrm{ foo{\cdot}bar }$",
+            id="units-only-fallback",
+        ),
+        pytest.param((), "eV/c", False, "eV/c", id="units-only-plain"),
+        pytest.param((), "", True, "", id="units-only-empty"),
+        pytest.param((), None, False, "", id="units-only-none-plain"),
+    ],
+)
+def test_mathlabel(keys, units, tex, expected) -> None:
+    assert mathlabel(*keys, units=units, tex=tex) == expected

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -81,6 +81,61 @@ def test_twiss():
     P.twiss("xy", fraction=0.95)
 
 
+def test_twiss_respects_weights():
+    """Twiss must use the weighted covariance: particles with (nearly) zero
+    weight should not influence the result."""
+    P2 = P.copy()
+    keep = np.arange(len(P2)) % 2 == 0
+    w = np.array(P2.weight, dtype=float).copy()
+    w[~keep] *= 1e-13  # effectively remove the odd-indexed particles
+    P2.weight = w
+
+    t_weighted = P2.twiss(plane="x")
+    t_subset = P[keep].twiss(plane="x")
+    assert t_weighted["beta_x"] == pytest.approx(t_subset["beta_x"], rel=1e-6)
+    # And the down-weighted group differs from the unmodified full group.
+    t_full = P.twiss(plane="x")
+    assert t_weighted["beta_x"] != pytest.approx(t_full["beta_x"], rel=1e-9)
+
+
+def test_twiss_match_forwards_p0c():
+    """twiss_match must forward p0c to matched_particles."""
+    from beamphysics.statistics import matched_particles
+
+    via_method = P.twiss_match(beta=10, alpha=0, plane="x", p0c=2 * P["mean_p"])
+    direct = matched_particles(P, beta=10, alpha=0, plane="x", p0c=2 * P["mean_p"])
+    np.testing.assert_allclose(via_method.px, direct.px)
+    # And a different p0c gives a different result.
+    other = P.twiss_match(beta=10, alpha=0, plane="x", p0c=P["mean_p"])
+    assert not np.allclose(via_method.px, other.px)
+
+
+def test_slice_statistics_twiss_keys_filled():
+    """Requesting twiss keys must return computed per-slice twiss values,
+    never an uninitialized array under the raw key."""
+    from beamphysics.statistics import slice_statistics
+
+    sdat = slice_statistics(P, keys=["mean_z", "twiss_x"], n_slice=5, slice_key="z")
+    assert "twiss_x" not in sdat  # expanded, not returned raw
+    assert "twiss_beta_x" in sdat
+    assert np.all(np.isfinite(sdat["twiss_beta_x"]))
+
+
+def test_eq_checks_species_and_does_not_assign_ids():
+    """Comparing two groups must not assign ids as a side effect, and
+    groups of different species must not compare equal."""
+    P1 = P.copy()
+    P2 = P.copy()
+    P1._data.pop("id", None)
+    P2._data.pop("id", None)
+    assert P1 == P2
+    assert "id" not in P1._data and "id" not in P2._data  # no side effect
+
+    P3 = P.copy()
+    P3._data["species"] = "positron"
+    assert P != P3
+
+
 def test_write_reload(tmp_path):
     h5file = os.path.join(tmp_path, "test.h5")
     P.write(h5file)

--- a/tests/test_plot_labels.py
+++ b/tests/test_plot_labels.py
@@ -7,7 +7,6 @@ matplotlib.use("Agg")
 import pytest
 
 from beamphysics import single_particle
-from beamphysics.labels import mathlabel
 from beamphysics.plot import (
     _charge_density_units_str,
     marginal_plot,
@@ -116,17 +115,6 @@ def test_plottable_array_and_units_tolerates_unparseable_strings() -> None:
     assert units_str == "1e3 counts"
     _, _, units_str, _, _ = plottable_array_and_units(arr, "counts", nice=False)
     assert units_str == "counts"
-
-
-def test_mathlabel_units_only() -> None:
-    """mathlabel with no keys is a units-only label, as used by the
-    marginal histograms."""
-    assert mathlabel(units="") == ""
-    assert mathlabel(units="A") == r"$\mathrm{A}$"
-    assert mathlabel(units="C/(eV/c)") == r"$\mathrm{C}/(\mathrm{eV}/\mathrm{c})$"
-    # Unparseable falls back to mathrm with * -> cdot.
-    assert r"{\cdot}" in mathlabel(units="foo*bar")
-    assert mathlabel(units="eV/c", tex=False) == "eV/c"
 
 
 def test_single_particle_plots_draw() -> None:

--- a/tests/test_statistics_standard.py
+++ b/tests/test_statistics_standard.py
@@ -186,11 +186,13 @@ class TestComputedStatistics:
         assert len(computed["statistics"]) > 0
 
     def test_computed_statistics_count(self, computed):
-        """Test that the expected number of statistics are generated."""
-        # 6 operators * 31 keys = 186 operator stats
-        # 31 * 31 = 961 covariance stats
-        # Total = 1147
-        assert len(computed["statistics"]) == 1147
+        """Test that the expected number of statistics are generated:
+        one stat per (operator, key) plus a covariance per key pair."""
+        from beamphysics.standards.statistics import ARRAY_KEYS, OPERATORS
+
+        n = len(ARRAY_KEYS)
+        expected = len(OPERATORS) * n + n * n
+        assert len(computed["statistics"]) == expected
 
     def test_computed_categories_exist(self, computed):
         """Test that computed statistics have categories."""


### PR DESCRIPTION
Follow-up to #142. While reviewing every consumer of `beamphysics.units` for that PR — and in a subsequent bug sweep over the interfaces, fields, wakefields, and core modules — a collection of small bugs unrelated to the units machinery turned up. The mechanical, low-risk fixes are collected here; physics-level findings are deferred to their own PRs (see the last section).

## 1. Genesis2 `.dpa` momentum reconstruction (bug)

`beamphysics/interfaces/genesis.py::genesis2_dpa_to_data`:

```diff
- pz = np.sqrt((gamma**2 - 1) * mc2**2 - px**2 - py * 2)
+ pz = np.sqrt((gamma**2 - 1) * mc2**2 - px**2 - py**2)
```

The relation is p² = px² + py² + pz²; the typo corrupted every `pz` read from a `.dpa` file with nonzero `py`.

Also in `genesis4_par_to_data`: a `units` dict was populated from the file attributes and then never used — removed.

## 2. Twiss ignored particle weights (bug)

`beamphysics/statistics.py::particle_twiss_dispersion` computed the weighted covariance and discarded it:

```diff
- np.cov([x, xp, delta], aweights=P.weight)
- twiss = twiss_dispersion_calc(np.cov([x, xp, delta]))
+ sigma = np.cov([x, xp, delta], aweights=P.weight)
+ twiss = twiss_dispersion_calc(sigma)
```

So `ParticleGroup.twiss()` ignored weights, unlike every other statistic (`avg`, `std`, `cov` all weight). A regression test verifies that a group with half its particles down-weighted to ~zero matches the equivalent subset.

**Compatibility note:** twiss results change for unequally-weighted distributions. Equal-weight distributions are unaffected.

## 3. Statistics standard: wrong covariance units (bug)

`beamphysics/standards/statistics.py::_multiply_units` wrote `f"{unit}^2"` for equal units, so `cov_px__px` documented units of `eV/c^2` — which parses as eV/(c²), a *mass* — instead of (eV/c)². It now delegates to `pmd_unit` multiplication, matching what `pg_units` computes at runtime (`eV/c*eV/c`):

```python
def _multiply_units(unit1: str, unit2: str) -> str:
    return (pmd_unit(unit1) * pmd_unit(unit2)).unitSymbol
```

Related cleanups in the same module:

- `ARRAY_KEYS` gains the missing `y_bar py_bar` (the x-plane twins were already listed), so `sigma_y_bar`, `cov_y_bar__py_bar`, etc. now resolve. The computed-statistics standard grows from 1147 to 1287 entries; the count test now derives the expectation from `ARRAY_KEYS`/`OPERATORS` instead of hardcoding it.
- The generated markdown renders `unitSI`/`unitDimension` via `:g` (no `.0` noise from the float dimension tuples introduced in #142).
- `validate_against_particlegroup` caught `except (AttributeError, KeyError, Exception)` — i.e. everything — when probing each label, turning any failure (including bugs in the lookup itself) into a "not accessible" warning. Narrowed to `except (AttributeError, KeyError, ValueError)`: exactly the exceptions `ParticleGroup.__getitem__` raises to signal an unsupported key. Any other error now propagates loudly instead of being downgraded to a warning string.

## 4. Twiss/slice statistics correctness (bugs)

- **`ParticleGroup.twiss_match` silently dropped its `p0c` argument** (`particles.py`): it was accepted but never forwarded to `matched_particles`, so a user-supplied reference momentum was ignored. Now forwarded; regression test compares against calling `matched_particles` directly.
- **`particle_twiss_dispersion` mixed normalizations** (`statistics.py`): `xp` used the supplied `p0c` while `delta` and `norm_emit` used `mean_p`, so an explicit `p0c != mean_p` produced inconsistently-normalized dispersion and normalized emittance. All three now use `p0c` (identical results at the default `p0c=None`).
- **`slice_statistics` returned uninitialized memory** (`statistics.py`): every requested key was allocated with `np.empty`, but twiss-style keys (`twiss_x`, `twiss_xy`) are expanded into `twiss_beta_x` etc. and the raw key was never filled — the caller got garbage under `'twiss_x'`. Arrays are now allocated only for keys that get filled; regression test included.
- **`ParticleGroup.__eq__` mutated its operands and ignored species** (`particles.py`): the key list included `"id"`, and accessing `self["id"]` *assigns* fresh ids to any group lacking them — so an equality check wrote new data into both operands (and two id-less groups always compared id-equal trivially). It also never compared `species`, so an electron and positron bunch with identical arrays compared equal. Now: species is compared, ids are compared only when already present, and the check is side-effect-free. Regression test included.

## 5. Interface writer/reader fixes (bugs)

- **`write_impact` mutated the caller's beam** (`impact.py`): the cathode-start small-`pz` shift operated on the ParticleGroup's internal array (`pz[small_pz] += pz_small`), permanently modifying the input. Now operates on a copy; regression test included.
- **`write_lucretia` silently wrote nothing when `stop_ix` was given** (`lucretia.py`): a misindented `return` sat at the `if` level instead of inside it, so any caller passing a real `stop_ix` array hit the `else` and returned before `savemat` — no file, no error. The length check is now a `ValueError` and a valid `stop_ix` writes the file. Regression test included.
- **`create_fourier_data` had a dead r=0 guard** (`impact.py`): `len(np.where(...))` is the array's ndim (always 1), so the check could never fire and a missing r=0 surfaced as a bare `IndexError`. Now checks the index array itself.
- **CST reader error handling** (`cst.py`): an unknown unit string (e.g. `[cm]`) returned `None` and propagated into `array * None` far from the cause; a file with neither 6 nor 9 columns hit `NameError`. Both now raise `ValueError` at the source. Regression test included.
- **`Wavefront.from_genesis4` crashed on `h5py.Group` input** (`wavefront/wavefront.py`): the branch referenced `h5`, a name only bound in the str/Path branch (`NameError`). Now uses `file`.
- **`ansys.py` magnetic-component loop** iterated `components1` (the E-field dict) to index `components2` — works only while both parsers return identical keys; now iterates the dict it reads.
- **`gpt.py`**: the pure-electric 1D fieldmap branch computed `dat["Er"]` that was never written (dead leftover) — removed; the post-write hints said `asci2df` where the GPT tool is `asci2gdf` (4 sites).
- **`astra.py`/`superfish.py`**: `assert len(iangle) == 1, print(iangle)` — the assert message was `print`'s return value (`None`). Now a real f-string message.

## 6. FieldMesh / plot fixes (bugs)

- **Duplicate-component guard checked the wrong dict** (`fields/fieldmesh.py::load_field_data_dict`): `assert k not in data` tested the outer `{'attrs','components'}` dict, so a dict containing both `electricField/z` and its alias `Ez` silently let one overwrite the other. Review caught that the first fix only guarded the alias branch (alias-first ordering still slipped through); the loop now translates aliases to canonical names first and applies a single duplicate check, so the collision is caught regardless of dict insertion order. Regression test parametrized over both orderings.
- **Rectangular `FieldMesh.plot(..., return_figure=True)` returned `None`**: the branch didn't return, and `plot_fieldmesh_rectangular_2d` never implemented its documented `return_figure`. Both fixed (matching the cylindrical path). Review of that fix surfaced a related pre-existing break: both rectangular plotters bound `fig` only when creating their own axes, so a caller-provided `axes` hit `UnboundLocalError` (at `fig.colorbar` in the 2D plotter, at `return fig` in the 1D one). `fig` is now taken from `axes.get_figure()` in that path; regression test covers provided-axes + `return_figure`.
- **`fields/analysis.py`**: `solenoid_analysis` called `np.trapezoid` directly, bypassing the module's own numpy<2 `trapezoid`/`trapz` shim (breaks on numpy 1.x); the `axs[2,1]` diff block set zorder/patch on `axs[1,1]`/`ax202` (copy-paste from the wrong panel); the cartesian curl-E panels plotted `+Re[iωB]` but labeled it `−Re[iωB]` — label-only fix, no plotted quantity changed. The `+iωB` comparison is correct under the package's exp(−iωt) phasor convention (∇×E = −∂B/∂t → ∇×Ê = +iωB̂), the panel's own residual computes `Re[∇×E] − Re[iωB]` (the curves are meant to coincide), and the cylindrical counterpart in the same file already labels the identical expression `Re[iωB_θ]` without the minus.
- **`plot.py::slice_plot`**: `ymin = max(of per-key minima)` — for multi-key plots the lower bound should be the smallest minimum (`min`).

## 7. Validation `assert`s: messages and exceptions

`beamphysics/fields/fieldmesh.py` validated HDF5 file contents (component `unitDimension`, grid shape) with `assert`, which is stripped under `python -O` and gives poor messages. Both checks now raise `ValueError` with the expected/found values.

A follow-up sweep covered every remaining message-less `assert` in the package (19 sites). Checks that validate caller or file input — geometry requirements in the plot/expansion/conversion/interface writers, species restrictions (litrack, genesis), Genesis `.dpa`/`.par` shape checks, OPAL `ptype`, CST E/B grid consistency, on-axis-field realness (expansion, impact), and `_scalar_maybe_from_array` — now raise `ValueError` with informative messages. The two genuine internal invariants (`resample_particles` branch logic, the `testing` helper's species check) keep their `assert` but gained messages. The earlier `assert len(iangle) == 1, print(iangle)` cases (astra, superfish) — whose "message" was `print`'s return value, `None` — were fixed with real f-strings.

## 8. Docstring and comment corrections

- `particles.py`: `average_current` formula (said `*c_light*beta_z`, code divides); `norm_emit_y` said "x plane"; `n_dead` said "alive particles"; `drift_to_t` said "If no z is given"; `rotate()` documented `yc` and `zc` both as "x coordinate".
- `statistics.py`: `matched_particles` said "x, py if plane == 'y'".
- `interfaces/elegant.py`: column lists read "x, xp, y, xp" (×2).
- `interfaces/impact.py`: "GBy = gamma*beta_x" → GBx.
- `wakefields/base.py`: `convolve_density` return documented as [V]; it is [V/m].
- `wakefields/pseudomode.py`: accumulator comment said "trailing particles" where it holds the particles ahead.
- `wakefields/resistive_wall/impedance.py`: plot default documented as `100 * s0`; code uses `20 * s0`.

## 9. Test refactors

- `tests/test_labels.py` — refactored into a single `pytest.mark.parametrize` table (`mathlabel(*keys, units=..., tex=...) == expected`), per review feedback on #142; adding cases is now one line. The units-only (`no keys`) cases moved here from `tests/test_plot_labels.py`.
- `tests/test_interfaces.py` — new; regression tests for §5 (impact mutation, lucretia stop_ix, CST units).
- `tests/test_particlegroup.py` — weighted-twiss (§2), `twiss_match` p0c (§4), slice twiss keys (§4), `__eq__` species/id (§4).
- `tests/test_fieldmesh.py` — duplicate-component alias rejection (§6).
- `tests/test_statistics_standard.py` — derived count test (§3).

## Found but deferred to other PRs

Physics-level findings from the same sweep, kept out of this PR because they change numerical output and deserve dedicated tests/review:

- `fields/expansion.py`: `f0` vs `f1` term in the radial RF expansion (corrupts Er/Br for `method="fft"`; verified against the spline method); `zmirror="auto"` always mirrors (truthy string); TE-mode `Etheta` scaled by ω²/c² instead of ω.
- `fields/corrector_modeling.py` (saddle-coil cluster): `p21 = p22 + offset` typo; second arc call missing `offset`/`rotation_matrix`; `make_saddle_dipole_corrector_fieldmesh` drops `offset`/`rotation_matrix`; `rotate_around_e3` bottom-right element 0 (should be 1); hardcoded `plot_wire=True`; `if offset:` crashes on ndarray; pitch/yaw mapping contradicts docstrings.
- `interfaces/simion.py`: `identify_species` rounds `mec2` instead of `mass`; writer/reader AZ sign mismatch (round trip negates px); CWF column writes total charge instead of per-particle weight.
- `interfaces/astra.py`: probe-particle times written in seconds amid ns columns; probe `z` retains stale `-z_ref`.
- `interfaces/genesis.py`: `.dpa` z-spreading formula disagrees with its comment for `zsep != 1`.
- Remaining *messaged* `assert`s that validate file content across the interfaces (the message-less ones were converted in §7); `superfish.py` T7 reader ignores a nonzero rmin; `bunching` z-approximation sign convention differs from `apply_wakefield`.

## Files changed

- `beamphysics/interfaces/genesis.py` — §1
- `beamphysics/statistics.py` — §2, §4, §8
- `beamphysics/standards/statistics.py` — §3
- `beamphysics/particles.py` — §4, §8
- `beamphysics/interfaces/impact.py`, `lucretia.py`, `cst.py`, `ansys.py`, `gpt.py`, `astra.py`, `superfish.py`, `elegant.py`, `litrack.py`, `opal.py` — §5, §7, §8
- `beamphysics/wavefront/wavefront.py` — §5
- `beamphysics/fields/fieldmesh.py` — §6, §7
- `beamphysics/fields/analysis.py` — §6
- `beamphysics/fields/expansion.py`, `beamphysics/fields/conversion.py`, `beamphysics/testing.py` — §7
- `beamphysics/plot.py` — §6, §7
- `beamphysics/wakefields/base.py`, `pseudomode.py`, `resistive_wall/impedance.py` — §8
- `tests/test_interfaces.py` (new), `tests/test_labels.py`, `tests/test_plot_labels.py`, `tests/test_particlegroup.py`, `tests/test_fieldmesh.py`, `tests/test_statistics_standard.py` — §9

## Test results

```
1817 passed, 1 xpassed, 3 warnings in ~12s
```

## Acknowledgment

These issues were found and fixed in collaboration with **Claude** (Anthropic, via Claude Code) during and after the package-wide review for #142.
