### PR TITLE
Use default_id in equality check

### DIFF
--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -1849,8 +1849,7 @@ class ParticleGroup:
             if self_has_id or other_has_id:
                 self_id = self._data["id"] if self_has_id else default_id(len(self))
                 other_id = other._data["id"] if other_has_id else default_id(len(other))
-                if not np.array_equal(self_id, other_id):
-                    return False
+                return np.array_equal(self_id, other_id)
             return True
 
         return NotImplemented

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -387,7 +387,7 @@ class ParticleGroup:
         """
         if "id" not in self._settable_array_keys:
             self._settable_array_keys.append("id")
-        self.id = np.arange(1, self["n_particle"] + 1)
+        self.id = default_id(self["n_particle"])
 
     @property
     def n_particle(self):
@@ -1836,15 +1836,20 @@ class ParticleGroup:
         if isinstance(other, ParticleGroup):
             if self.species != other.species:
                 return False
-            # Only compare ids that already exist: accessing self["id"] would
-            # otherwise *assign* fresh ids to both operands as a side effect.
-            if ("id" in self._data) != ("id" in other._data):
-                return False
             keys = ["x", "px", "y", "py", "z", "pz", "t", "status", "weight"]
-            if "id" in self._data:
-                keys.append("id")
             for key in keys:
                 if not np.allclose(self[key], other[key]):
+                    return False
+
+            # Compare ids without triggering assign_id as a side effect. If only
+            # one operand has explicit ids, compare them against the default ids
+            # (1..n) that assign_id would otherwise produce for the other.
+            self_has_id = "id" in self._data
+            other_has_id = "id" in other._data
+            if self_has_id or other_has_id:
+                self_id = self._data["id"] if self_has_id else default_id(len(self))
+                other_id = other._data["id"] if other_has_id else default_id(len(other))
+                if not np.array_equal(self_id, other_id):
                     return False
             return True
 
@@ -2211,6 +2216,23 @@ def load_bunch_data(h5):
         data["id"] = h5["id"][:]
 
     return data
+
+
+def default_id(n):
+    """
+    Return the default particle ids: integers from 1 to ``n``.
+
+    Parameters
+    ----------
+    n : int
+        Number of particles.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array ``[1, 2, ..., n]``.
+    """
+    return np.arange(1, n + 1)
 
 
 def full_array(n, val):

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -136,6 +136,31 @@ def test_eq_checks_species_and_does_not_assign_ids():
     assert P != P3
 
 
+def test_eq_default_ids_match_missing_ids():
+    """A group whose explicit ids are the default 1..n must compare equal to an
+    otherwise-identical group that has no ids stored."""
+    P1 = P.copy()
+    P2 = P.copy()
+    P1._data.pop("id", None)
+    P2.assign_id()  # default ids: 1..n
+    assert np.array_equal(P2._data["id"], np.arange(1, len(P2) + 1))
+    assert P1 == P2
+    assert P2 == P1  # symmetric
+    assert "id" not in P1._data  # no side effect
+
+
+def test_eq_custom_ids_differ_from_missing_ids():
+    """A group with explicit non-default ids must not compare equal to an
+    otherwise-identical group that has no ids (which would default to 1..n)."""
+    P1 = P.copy()
+    P2 = P.copy()
+    P1._data.pop("id", None)
+    P2.id = np.arange(1, len(P2) + 1) + 100  # non-default ids
+    assert P1 != P2
+    assert P2 != P1  # symmetric
+    assert "id" not in P1._data  # no side effect
+
+
 def test_write_reload(tmp_path):
     h5file = os.path.join(tmp_path, "test.h5")
     P.write(h5file)


### PR DESCRIPTION
Previously two ParticleGroups `__eq__` comparison would return False if one had an id array = 1-N, which is the default, and the other didn't have this assigned. This checks against the default for differences. 

Claude notes:

## Summary

`ParticleGroup.__eq__` previously returned `False` whenever one operand had an
explicit `id` array and the other did not — even when the operand without ids
would, on access, be assigned the default ids `1..n` that exactly matched the
other operand. This made two otherwise-identical particle groups compare unequal
purely because of how ids were stored.

## Changes

- **`beamphysics/particles.py`**
  - Added a module-level `default_id(n)` helper that returns the default
    particle ids (`np.arange(1, n + 1)`).
  - Updated `assign_id` to use `default_id` for consistency.
  - Reworked `__eq__`:
    - Compares all non-id arrays (`x`, `px`, `y`, `py`, `z`, `pz`, `t`,
      `status`, `weight`) first.
    - For ids, if only one operand has an explicit `id` array, the existing id
      is compared against the default `1..n` ids the other operand would receive
      from `assign_id`.
    - Avoids triggering `assign_id` as a side effect (accessing `self["id"]`
      would otherwise assign fresh ids to both operands).

## Behavior

| Left ids        | Right ids       | Result                                    |
| --------------- | --------------- | ----------------------------------------- |
| none            | none            | equal (ids not compared)                  |
| `1..n` default  | none            | **equal** (was previously unequal)        |
| explicit custom | none            | equal only if custom ids == `1..n`        |
| explicit        | explicit        | equal only if id arrays match             |

## Notes

- No side effects: comparison no longer mutates either operand by assigning ids.
- Docstrings follow numpydoc style.
