### PR TITLE
FIX: ParticleGroup id/status must be integer arrays

### DIFF
--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -2257,8 +2257,15 @@ def _round_to_int_array(val):
 
 def full_array(n, val, dtype=None):
     """
-    Casts a value into a full array of length n
+    Casts a value into a full array of length n.
+
+    Special handling for `int` dtype rounds floating point values first, if
+    provided.
     """
+
+    if dtype is not None and np.issubdtype(dtype, np.integer):
+        val = np.round(val)
+
     if np.isscalar(val):
         return np.full(n, val, dtype=dtype)
     n_here = len(val)

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -239,7 +239,15 @@ class ParticleGroup:
         self._settable_scalar_keys = ["species"]
         self._settable_keys = self._settable_array_keys + self._settable_scalar_keys
         # Internal data. Only allow settable keys
-        self._data = {k: data[k] for k in self._settable_keys}
+
+        def fix_dtype(key: str, arr: np.ndarray) -> np.ndarray:
+            if key in self._settable_scalar_keys:
+                return arr  # passthrough
+            if key in {"id", "status"}:
+                return np.asarray(arr, dtype=int)
+            return np.asarray(arr, dtype=float)
+
+        self._data = {key: fix_dtype(key, data[key]) for key in self._settable_keys}
 
     # -------------------------------------------------
     # Access to intrinsic coordinates

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -329,7 +329,7 @@ class ParticleGroup:
 
     @status.setter
     def status(self, val):
-        self._data["status"] = full_array(len(self), val)
+        self._data["status"] = full_array(len(self), val, dtype=int)
 
     @property
     def weight(self):
@@ -356,7 +356,7 @@ class ParticleGroup:
     def id(self, val):
         if "id" not in self._settable_array_keys:
             self._settable_array_keys.append("id")
-        self._data["id"] = full_array(len(self), val)
+        self._data["id"] = full_array(len(self), val, dtype=int)
 
     @property
     def species(self):
@@ -2234,20 +2234,20 @@ def default_id(n):
     return np.arange(1, n + 1)
 
 
-def full_array(n, val):
+def full_array(n, val, dtype=None):
     """
     Casts a value into a full array of length n
     """
     if np.isscalar(val):
-        return np.full(n, val)
+        return np.full(n, val, dtype=dtype)
     n_here = len(val)
 
     if n_here == 1:
-        return np.full(n, val[0])
+        return np.full(n, val[0], dtype=dtype)
     elif n_here != n:
         raise ValueError(f"Length mismatch: len(val)={n_here}, but requested n={n}")
     # Cast to array
-    return np.array(val)
+    return np.array(val, dtype=dtype)
 
 
 def full_data(data, exclude=None):

--- a/beamphysics/particles.py
+++ b/beamphysics/particles.py
@@ -244,7 +244,7 @@ class ParticleGroup:
             if key in self._settable_scalar_keys:
                 return arr  # passthrough
             if key in {"id", "status"}:
-                return np.asarray(arr, dtype=int)
+                return _round_to_int_array(arr)
             return np.asarray(arr, dtype=float)
 
         self._data = {key: fix_dtype(key, data[key]) for key in self._settable_keys}
@@ -2240,6 +2240,19 @@ def default_id(n):
         Array ``[1, 2, ..., n]``.
     """
     return np.arange(1, n + 1)
+
+
+def _round_to_int_array(val):
+    """
+    Coerce `val` into a `np.ndarray` with `dtype` int by way of rounding (if necessary).
+    """
+    if not isinstance(val, np.ndarray):
+        val = np.asarray(val)
+
+    if np.issubdtype(val.dtype, int):
+        return val
+
+    return np.asarray(np.round(val), dtype=int)
 
 
 def full_array(n, val, dtype=None):

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -219,3 +219,36 @@ def test_id_ensure_int():
     for key in P._settable_array_keys:
         if key not in {"id", "status"}:
             assert np.issubdtype(getattr(P, key).dtype, float), key
+
+
+@pytest.mark.parametrize(
+    ("val", "expected"),
+    [
+        pytest.param(
+            [0.0, 1.0],
+            np.asarray([0, 1]),
+            id="list-float",
+        ),
+        pytest.param(
+            [0.0, 0.999],
+            np.asarray([0, 1]),
+            id="list-float-rounded",
+        ),
+        pytest.param(
+            np.array([0.0, 1.0]),
+            np.asarray([0, 1]),
+            id="ndarray-float",
+        ),
+        pytest.param(
+            np.array([0.0, 0.999]),
+            np.asarray([0, 1]),
+            id="ndarray-float-rounded",
+        ),
+    ],
+)
+def test_coerce_int_array_round(val, expected: np.ndarray):
+    from beamphysics.particles import _round_to_int_array
+
+    result = _round_to_int_array(val)
+    np.testing.assert_array_equal(actual=result, desired=expected)
+    assert np.issubdtype(result.dtype, int)

--- a/tests/test_particlegroup.py
+++ b/tests/test_particlegroup.py
@@ -203,3 +203,19 @@ def test_plot_single_particle_vs_z(array_key: str):
     Ps = single_particle(pz=10e6)
     Ps.plot("z", array_key)
     plt.show()
+
+
+def test_id_ensure_int():
+    data = single_particle().data
+    data.pop("status", None)
+    data.pop("id", None)
+
+    P = ParticleGroup(data={**data, "status": [0.1], "id": [0.0]})
+    np.testing.assert_array_equal(P.status, [0])
+    np.testing.assert_array_equal(P.id, [0])
+    assert np.issubdtype(P.status.dtype, int)
+    assert np.issubdtype(P.id.dtype, int)
+
+    for key in P._settable_array_keys:
+        if key not in {"id", "status"}:
+            assert np.issubdtype(getattr(P, key).dtype, float), key


### PR DESCRIPTION
* Coerce `id`/`status` into `dtype=int`
* Other settable arrays get `dtype=float`

`asarray()` gives you back the original if it's compatible with the requested `dtype`, so I think filtering all of the data through it is reasonable.